### PR TITLE
Join to the WriterThread after running the tests.

### DIFF
--- a/source/unit_threaded/runner.d
+++ b/source/unit_threaded/runner.d
@@ -102,6 +102,7 @@ bool runTests(MOD_SYMBOLS...)(in Options options) if(!anySatisfy!(isSomeString, 
 
     utWritelnGreen("OK!\n");
 
+    WriterThread.get().join();
     return true;
 }
 


### PR DESCRIPTION
This fixes issues when running with vibe.d (doesn't cause the app to hang anymore)