### PR TITLE
Fixed test function discovering for AliasSeq's

### DIFF
--- a/source/unit_threaded/reflection.d
+++ b/source/unit_threaded/reflection.d
@@ -150,7 +150,8 @@ TestData[] moduleTestFunctions(alias module_)() pure {
 
     template isTestFunction(alias module_, string moduleMember) {
         mixin("import " ~ fullyQualifiedName!module_ ~ ";"); //so it's visible
-        static if(isSomeFunction!(mixin(moduleMember))) {
+        // AliasSeq aren't passed as a single argument, but isSomeFunction only takes one
+        static if(AliasSeq!(mixin(moduleMember)).length == 1 && isSomeFunction!(mixin(moduleMember))) {
             enum isTestFunction = hasTestPrefix!(module_, moduleMember) ||
                 HasAttribute!(module_, moduleMember, UnitTest);
         } else {

--- a/source/unit_threaded/tests/module_with_tests.d
+++ b/source/unit_threaded/tests/module_with_tests.d
@@ -3,6 +3,7 @@ module unit_threaded.tests.module_with_tests;
 import unit_threaded.attrs;
 
 version(unittest) {
+    import std.meta;
     import unit_threaded.should;
 
     //test functions
@@ -27,6 +28,9 @@ version(unittest) {
 
     @HiddenTest void withHidden() {}
     void withoutHidden() { }
+
+    //other non-test members
+    alias seq = AliasSeq!(int, float, string);
 }
 
 


### PR DESCRIPTION
Fix for #12. Checks that the member is in fact only one.