### PR TITLE
Made unit_threaded.should.fail public

### DIFF
--- a/source/unit_threaded/should.d
+++ b/source/unit_threaded/should.d
@@ -517,7 +517,7 @@ package void utFail(in string output, in string file, in size_t line)
     fail(output, file, line);
 }
 
-private void fail(in string output, in string file, in size_t line)
+void fail(in string output, in string file, in size_t line)
 {
     throw new UnitTestException([output], file, line);
 }


### PR DESCRIPTION
I am often writing my own should functions, and would like access to the fail function.

While I could use the UnitTestException class, I find fail() easier to write.