### PR TITLE
Fix for DMD 2.069 and 2.070.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ matrix:
         - d: dmd-2.070.2
         - d: dmd-2.069.2
         - d: ldc
-        - d: ldc-0.17.1
+        - d: ldc-1.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: d
 sudo: false
+
+matrix:
+    include:
+        - d: dmd
+        - d: dmd-2.071.2
+        - d: dmd-2.070.2
+        - d: dmd-2.069.2
+        - d: ldc
+        - d: ldc-0.17.1

--- a/source/unit_threaded/property/package.d
+++ b/source/unit_threaded/property/package.d
@@ -137,7 +137,7 @@ T shrink(alias F, T)(T value) {
 }
 
 private T shrinkImpl(alias F, T)(T value, T[] values) if(isIntegral!T) {
-    import std.algorithm: canFind, minPos, maxPos;
+    import std.algorithm: canFind, minPos;
     import std.traits: isSigned;
 
     if(value < T.max && F(value + 1)) return value;
@@ -164,7 +164,7 @@ private T shrinkImpl(alias F, T)(T value, T[] values) if(isIntegral!T) {
             return shrinkImpl!F(attempt, values);
 
     auto min = values.minPos[0];
-    auto max = values.maxPos[0];
+    auto max = values.minPos!"a > b"[0]; // maxPos doesn't exist before DMD 2.071.0
 
     if(!F(min)) return shrinkImpl!F(min, values);
     if(!F(max)) return shrinkImpl!F(max, values);


### PR DESCRIPTION
A very minor change is able to make this work for DMD 2.069 and 2.070. Also add supported compilers to .travis.yml.