### PR TITLE
Add -t/--trace to show stack traces. Also fixes #44

### DIFF
--- a/source/unit_threaded/options.d
+++ b/source/unit_threaded/options.d
@@ -15,6 +15,7 @@ struct Options {
     bool forceEscCodes;
     bool random;
     uint seed;
+    bool stackTraces;
 }
 
 /**
@@ -28,6 +29,7 @@ auto getOptions(string[] args) {
     bool forceEscCodes;
     bool random;
     uint seed = unpredictableSeed;
+    bool stackTraces;
 
     getopt(args,
            "single|s", &single, //single-threaded
@@ -37,6 +39,7 @@ auto getOptions(string[] args) {
            "list|l", &list,
            "random|r", &random,
            "seed", &seed,
+           "trace|t", &stackTraces,
         );
 
     if(help) {
@@ -49,6 +52,7 @@ auto getOptions(string[] args) {
                 "  -e/--esccodes: force ANSI escape codes even for !isatty\n",
                 "  -r/--random: run tests in random order\n",
                 "  --seed: set the seed for the random order\n",
+                "  -t/--trace: enable stack traces\n",
             );
     }
 
@@ -66,5 +70,5 @@ auto getOptions(string[] args) {
 
     immutable exit =  help || list;
     return Options(!single, args[1..$], debugOutput, list, exit, forceEscCodes,
-                   random, seed);
+                   random, seed, stackTraces);
 }

--- a/source/unit_threaded/runner.d
+++ b/source/unit_threaded/runner.d
@@ -8,7 +8,7 @@ module unit_threaded.runner;
 import unit_threaded.testsuite;
 import unit_threaded.options;
 import unit_threaded.io : enableDebugOutput, forceEscCodes;
-import unit_threaded.testcase : TestData;
+import unit_threaded.testcase : enableStackTrace, TestData;
 import unit_threaded.reflection : allTestData;
 
 import std.conv : text;
@@ -80,4 +80,7 @@ private void handleCmdLineOptions(in Options options, in TestData[] testData) {
 
     if (options.forceEscCodes)
         forceEscCodes();
+
+    if (options.stackTraces)
+        enableStackTrace();
 }

--- a/source/unit_threaded/testcase.d
+++ b/source/unit_threaded/testcase.d
@@ -178,13 +178,10 @@ class BuiltinTestCase: FunctionTestCase {
     override void test() {
         import core.exception: AssertError;
 
-        if (_stacktrace) {
+        try
             super.test();
-        } else {
-            try
-                super.test();
-            catch(AssertError e)
-                unit_threaded.should.fail(e.msg, e.file, e.line);
+        catch(AssertError e) {
+             unit_threaded.should.fail(_stacktrace? e.toString() : e.msg, e.file, e.line);
         }
     }
 }


### PR DESCRIPTION
This way, when a stack trace is needed, it can be requested via command line, without having to add a call to enableStackTrace in a static constructor and recompile.
