### PR TITLE
Renamed import to convert string to module

### DIFF
--- a/source/unit_threaded/reflection.d
+++ b/source/unit_threaded/reflection.d
@@ -38,17 +38,20 @@ struct TestData {
  * Template parameters are module strings
  */
 const(TestData)[] allTestData(MOD_STRINGS...)() if(allSatisfy!(isSomeString, typeof(MOD_STRINGS))) {
+    import std.array: join;
+    import std.range : iota;
+    import std.format : format;
+    import std.algorithm : map;
 
     string getModulesString() {
-        import std.array: join;
         string[] modules;
-        foreach(module_; MOD_STRINGS) modules ~= module_;
+        foreach(i, module_; MOD_STRINGS) modules ~= "module%d = %s".format(i, module_);
         return modules.join(", ");
     }
 
     enum modulesString =  getModulesString;
     mixin("import " ~ modulesString ~ ";");
-    mixin("return allTestData!(" ~ modulesString ~ ");");
+    mixin("return allTestData!(" ~ 0.iota(MOD_STRINGS.length).map!(i => "module%d".format(i)).join(", ") ~ ");");
 }
 
 


### PR DESCRIPTION
The function allTestData, that receives strings that names the module, will import the modules and pass it along using the module identifier.
The problem is that some identifier inside the  module might override and module name. In the snippet `import yada;` it is not guaranteed that `yada` identifier represents the module, it is possible that a identifier from within the module is named `yada` also.
By using renamed imports, it is possible to give an unique and non-ambiguous name for each imported module.
Remarks: Using static import will yield issues with packages, thats why renaming is prefered.