### PR TITLE
Struct Mock doesn't import modules

### DIFF
--- a/tests/pass/issue51.d
+++ b/tests/pass/issue51.d
@@ -14,7 +14,7 @@ import unit_threaded;
 
     enum isString(alias T) = is(typeof(T) == string);
     static assert(isString!"tests.pass.types");
-    auto m = mock!(Foo, __MODULE__, "tests.pass.types");
+    auto m = mock!(Foo);
     m.expect!"foo";
     fun(m);
 }

--- a/tests/pass/mock.d
+++ b/tests/pass/mock.d
@@ -34,3 +34,20 @@ import unit_threaded;
 void generic(T)(auto ref T thing) {
     thing.foo(2);
 }
+
+struct Namespace {
+    import std.datetime : Duration;
+    class HiddenTypes {
+        abstract Duration identity(Duration) pure @safe;
+    }
+}
+
+@safe pure unittest {
+    auto m = mock!(Namespace.HiddenTypes);
+    {
+        import std.datetime : Duration;
+        m.expect!"identity"(Duration.init);
+        m.identity(Duration.init);
+        m.verify;
+    }
+}


### PR DESCRIPTION
Changes how the struct Mock declare the return type and type of the parameters for an overriden of a function so that the module that contains such types may be not imported.
Aliases in the generated mixin are created to identify the types using traits on the identifier T which is the class that is being mocked.

Remarks: Perhaps we should keep the string template parameters on the function `mock` so to keep backward compatibility with code that specifies which modules must be imported.