### PR TITLE
getValue does not work anymore.

### DIFF
--- a/source/unit_threaded/attrs.d
+++ b/source/unit_threaded/attrs.d
@@ -76,6 +76,7 @@ auto Values(T)(T[] values...) {
     return ValuesImpl!T(values.dup);
 }
 
+import std.range.primitives : isInputRange;
 auto Values(R)(R values) if(isInputRange!R) {
     import std.array: array;
     return ValuesImpl!(ElementType!R)(values.array);


### PR DESCRIPTION
Because of the recent removes of top-module imports isInputRange is undefined. This is hidden until the function is used because it is a template.