### PR TITLE
Added a getFile function to Sandbox

### DIFF
--- a/source/unit_threaded/integration.d
+++ b/source/unit_threaded/integration.d
@@ -108,10 +108,8 @@ struct Sandbox {
     }
 
     /// Returns a File in the tests sandbox path
-    /// You must ensure you flush to or close the file
-    /// when finished.
     /// Returns: A temporary File in this testcases tmp directory
-    auto getFile(in string fileName) const {
+    auto tmpFile(in string fileName) const {
         import std.path : buildPath;
         import std.stdio: File;
         return File(buildPath(testPath, fileName), "w");
@@ -136,7 +134,7 @@ struct Sandbox {
 
         with(immutable Sandbox()) {
             assert(!buildPath(testPath, "foo.txt").exists);
-            File testFile = getFile("foo.txt");
+            File testFile = tmpFile("foo.txt");
             assert(buildPath(testPath, "foo.txt").exists);
 
             testFile.writef("Test %s", 1);

--- a/source/unit_threaded/integration.d
+++ b/source/unit_threaded/integration.d
@@ -107,6 +107,16 @@ struct Sandbox {
         writeFile(fileName, lines.join("\n"));
     }
 
+    /// Returns a File in the tests sandbox path
+    /// You must ensure you flush to or close the file
+    /// when finished.
+    /// Returns: A temporary File in this testcases tmp directory
+    auto getFile(in string fileName) const {
+        import std.path : buildPath;
+        import std.stdio: File;
+        return File(buildPath(testPath, fileName), "w");
+    }
+
     ///
     @safe unittest {
         import std.file;
@@ -116,6 +126,23 @@ struct Sandbox {
             assert(!buildPath(testPath, "foo.txt").exists);
             writeFile("foo.txt");
             assert(buildPath(testPath, "foo.txt").exists);
+        }
+    }
+
+    @safe unittest {
+        import std.stdio : File, writef, writeln;
+        import std.path : buildPath;
+        import std.file : exists;
+
+        with(immutable Sandbox()) {
+            assert(!buildPath(testPath, "foo.txt").exists);
+            File testFile = getFile("foo.txt");
+            assert(buildPath(testPath, "foo.txt").exists);
+
+            testFile.writef("Test %s", 1);
+            testFile.writeln("23");
+            testFile.close;
+            shouldEqualLines("foo.txt", ["Test 123"]);
         }
     }
 


### PR DESCRIPTION
Rationale for this:

I found it hard to test the output of a function in an app where I'm passing `File`s around.
This allows an easy way to get a temporary file in the testcases directory, and can pass that to my function under test.

I was building a `File` from Sandbox.testPath and using that, which is a semi-acceptable workaround.
But this is a little nicer.

The one thing I don't like is needing to flush / close the `File` before checking it's contents (as it likely hasn't been flushed yet if you've not written a lot to it).
I was thinking a wrapper around a `File` might be possible where you flush on every call to `write*` family functions, but that's a lot more added complexity.