### PR TITLE
replace in auto with scope auto

### DIFF
--- a/source/unit_threaded/light.d
+++ b/source/unit_threaded/light.d
@@ -115,15 +115,15 @@ void shouldEqual(V, E)(auto ref V value, auto ref E expected, in string file = _
     }
 }
 
-void shouldNotEqual(V, E)(in auto ref V value, in auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotEqual(V, E)(scope auto ref V value, scope auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
     assert_(value != expected, file, line);
 }
 
-void shouldBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeNull(T)(scope auto ref T value, in string file = __FILE__, in size_t line = __LINE__) {
     assert_(value is null, file, line);
 }
 
-void shouldNotBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotBeNull(T)(scope auto ref T value, in string file = __FILE__, in size_t line = __LINE__) {
     assert_(value !is null, file, line);
 }
 
@@ -135,12 +135,12 @@ static assert(isLikeAssociativeArray!(string[string], string));
 static assert(!isLikeAssociativeArray!(string[string], int));
 
 
-void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(scope auto ref T value, scope auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
     if(isLikeAssociativeArray!U) {
     assert_(cast(bool)(value in container), file, line);
 }
 
-void shouldBeIn(T, U)(in auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(scope auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T))
 {
     import std.algorithm: find;
@@ -148,12 +148,12 @@ void shouldBeIn(T, U)(in auto ref T value, U container, in string file = __FILE_
     assert_(!find(container, value).empty, file, line);
 }
 
-void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeIn(T, U)(scope auto ref T value, scope auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
     if(isLikeAssociativeArray!U) {
     assert_(!cast(bool)(value in container), file, line);
 }
 
-void shouldNotBeIn(T, U)(in auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeIn(T, U)(scope auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T))
 {
     import std.algorithm: find;
@@ -217,7 +217,7 @@ void shouldApproxEqual(V, E)(in V value, in E expected, string file = __FILE__, 
     assert_(approxEqual(value, expected), file, line);
 }
 
-void shouldBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeEmpty(R)(scope auto ref R rng, in string file = __FILE__, in size_t line = __LINE__) {
     import std.range: isInputRange;
     import std.traits: isAssociativeArray;
     import std.array;
@@ -230,7 +230,7 @@ void shouldBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t li
         static assert(false, "Cannot call shouldBeEmpty on " ~ R.stringof);
 }
 
-void shouldNotBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotBeEmpty(R)(scope auto ref R rng, in string file = __FILE__, in size_t line = __LINE__) {
     import std.range: isInputRange;
     import std.traits: isAssociativeArray;
     import std.array;
@@ -243,27 +243,27 @@ void shouldNotBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t
         static assert(false, "Cannot call shouldBeEmpty on " ~ R.stringof);
 }
 
-void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeGreaterThan(T, U)(scope auto ref T t, scope auto ref U u,
                                in string file = __FILE__, in size_t line = __LINE__)
 {
     assert_(t > u, file, line);
 }
 
-void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeSmallerThan(T, U)(scope auto ref T t, scope auto ref U u,
                                in string file = __FILE__, in size_t line = __LINE__)
 {
     assert_(t < u, file, line);
 }
 
-void shouldBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeSameSetAs(V, E)(scope auto ref V value, scope auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
     assert_(isSameSet(value, expected), file, line);
 }
 
-void shouldNotBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotBeSameSetAs(V, E)(scope auto ref V value, scope auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
     assert_(!isSameSet(value, expected), file, line);
 }
 
-private bool isSameSet(T, U)(in auto ref T t, in auto ref U u) {
+private bool isSameSet(T, U)(scope auto ref T t, scope auto ref U u) {
     import std.array: array;
     import std.algorithm: canFind;
 

--- a/source/unit_threaded/should.d
+++ b/source/unit_threaded/should.d
@@ -235,7 +235,7 @@ void shouldNotEqual(V, E)(V value, E expected, in string file = __FILE__, in siz
  * Verify that the value is null.
  * Throws: UnitTestException on failure
  */
-void shouldBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeNull(T)(scope auto ref T value, in string file = __FILE__, in size_t line = __LINE__)
 {
     if (value !is null)
         fail("Value is not null", file, line);
@@ -252,7 +252,7 @@ void shouldBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t l
  * Verify that the value is not null.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeNull(T)(scope auto ref T value, in string file = __FILE__, in size_t line = __LINE__)
 {
     if (value is null)
         fail("Value is null", file, line);
@@ -292,7 +292,7 @@ static assert(!isLikeAssociativeArray!(string[string], int));
  * Verify that the value is in the container.
  * Throws: UnitTestException on failure
 */
-void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(scope auto ref T value, scope auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
     if (isLikeAssociativeArray!(U, T))
 {
     import std.conv: to;
@@ -323,7 +323,7 @@ void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, in string fi
  * Verify that the value is in the container.
  * Throws: UnitTestException on failure
  */
-void shouldBeIn(T, U)(in auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(scope auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T) && isInputRange!U)
 {
     import std.algorithm: find;
@@ -348,7 +348,7 @@ void shouldBeIn(T, U)(in auto ref T value, U container, in string file = __FILE_
  * Verify that the value is not in the container.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container,
+void shouldNotBeIn(T, U)(scope auto ref T value, scope auto ref U container,
                          in string file = __FILE__, in size_t line = __LINE__)
     if (isLikeAssociativeArray!(U, T))
 {
@@ -381,7 +381,7 @@ void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container,
  * Verify that the value is not in the container.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeIn(T, U)(in auto ref T value, U container,
+void shouldNotBeIn(T, U)(scope auto ref T value, U container,
                          in string file = __FILE__, in size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T) && isInputRange!U)
 {
@@ -609,7 +609,7 @@ private string[] formatValue(T)(in string prefix, auto ref T value) {
 }
 
 // helper function for non-copyable types
-private string convertToString(T)(in auto ref T value) { // std.conv.to sometimes is @system
+private string convertToString(T)(scope auto ref T value) { // std.conv.to sometimes is @system
     import std.conv: to;
 
     static if(__traits(compiles, value.to!string))
@@ -647,7 +647,7 @@ private string[] formatRange(T)(in string prefix, T value) {
 
 private enum isObject(T) = is(T == class) || is(T == interface);
 
-private bool isEqual(V, E)(in auto ref V value, in auto ref E expected)
+private bool isEqual(V, E)(scope auto ref V value, scope auto ref E expected)
  if (!isObject!V &&
      (!isInputRange!V || !isInputRange!E) &&
      !isFloatingPoint!V && !isFloatingPoint!E &&
@@ -790,7 +790,7 @@ private void assertFail(E)(lazy E expression, in string file = __FILE__, in size
  * Verify that rng is empty.
  * Throws: UnitTestException on failure.
  */
-void shouldBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeEmpty(R)(scope auto ref R rng, in string file = __FILE__, in size_t line = __LINE__)
 if (isInputRange!R)
 {
     import std.conv: text;
@@ -858,7 +858,7 @@ if (isInputRange!R)
  * Verify that aa is not empty.
  * Throws: UnitTestException on failure.
  */
-void shouldNotBeEmpty(T)(in auto ref T aa, in string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeEmpty(T)(scope auto ref T aa, in string file = __FILE__, in size_t line = __LINE__)
 if (isAssociativeArray!T)
 {
     //keys is @system
@@ -890,7 +890,7 @@ if (isAssociativeArray!T)
  * Verify that t is greater than u.
  * Throws: UnitTestException on failure.
  */
-void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeGreaterThan(T, U)(scope auto ref T t, scope auto ref U u,
                                in string file = __FILE__, in size_t line = __LINE__)
 {
     import std.conv: text;
@@ -911,7 +911,7 @@ void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
  * Verify that t is smaller than u.
  * Throws: UnitTestException on failure.
  */
-void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeSmallerThan(T, U)(scope auto ref T t, scope auto ref U u,
                                in string file = __FILE__, in size_t line = __LINE__)
 {
     import std.conv: text;


### PR DESCRIPTION
in is  scope const. User-defined types may not work properly if they
are const.