### PR TITLE
Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,13 +36,23 @@ randomized_sources = [
     'source/unit_threaded/randomized/random.d',
 ]
 
+tests_sources = [
+    'source/unit_threaded/tests/issue33.d',
+    'source/unit_threaded/tests/module_with_attrs.d',
+    'source/unit_threaded/tests/module_with_setup.d',
+    'source/unit_threaded/tests/module_with_tests.d',
+    'source/unit_threaded/tests/parametrized.d',
+    'source/unit_threaded/tests/structs_are_not_classes.d',
+    'source/unit_threaded/tests/tags.d',
+]
+
 inc_dirs = [
     include_directories('source'),
 ]
 
 shared_library(
     meson.project_name(),
-    main_sources + randomized_sources,
+    main_sources + randomized_sources + tests_sources,
     include_directories: inc_dirs,
     version: meson.project_version(),
     soversion: '0',
@@ -51,7 +61,7 @@ shared_library(
 
 static_library(
     meson.project_name(),
-    main_sources + randomized_sources,
+    main_sources + randomized_sources + tests_sources,
     include_directories: inc_dirs,
     install: true,
 )
@@ -62,6 +72,10 @@ endforeach
 
 foreach item: randomized_sources
     install_data(item, install_dir: get_option('prefix') + '/include/d/unit_threaded/randomized')
+endforeach
+
+foreach item: tests_sources
+    install_data(item, install_dir: get_option('prefix') + '/include/d/unit_threaded/tests')
 endforeach
 
 # The pkgconfig system produces C/C++ library flags which are of
@@ -80,7 +94,7 @@ install_data(pc_file, install_dir: 'share/pkgconfig')
 
 #testExecutable = executable(
 #    'unit-threaded-test',
-#    main_sources + randomized_sources,
+#    main_sources + randomized_sources + tests_sources,
 #    include_directories: inc_dirs,
 #    d_args: ['-unittest'],
 #    link_args: ['--main'],

--- a/meson.build
+++ b/meson.build
@@ -7,44 +7,9 @@ project(
     default_options: ['buildtype=release'],
 )
 
-main_sources =  [
-    'source/unit_threaded/asserts.d',
-    'source/unit_threaded/attrs.d',
-    'source/unit_threaded/dub.d',
-    'source/unit_threaded/factory.d',
-    'source/unit_threaded/integration.d',
-    'source/unit_threaded/io.d',
-    'source/unit_threaded/light.d',
-    'source/unit_threaded/meta.d',
-    'source/unit_threaded/mock.d',
-    'source/unit_threaded/options.d',
-    'source/unit_threaded/package.d',
-    'source/unit_threaded/property.d',
-    'source/unit_threaded/reflection.d',
-    'source/unit_threaded/runner.d',
-    'source/unit_threaded/runtime.d',
-    'source/unit_threaded/should.d',
-    'source/unit_threaded/testcase.d',
-    'source/unit_threaded/testsuite.d',
-    'source/unit_threaded/uda.d',
-]
-
-randomized_sources = [
-    'source/unit_threaded/randomized/benchmark.d',
-    'source/unit_threaded/randomized/gen.d',
-    'source/unit_threaded/randomized/package.d',
-    'source/unit_threaded/randomized/random.d',
-]
-
-tests_sources = [
-    'source/unit_threaded/tests/issue33.d',
-    'source/unit_threaded/tests/module_with_attrs.d',
-    'source/unit_threaded/tests/module_with_setup.d',
-    'source/unit_threaded/tests/module_with_tests.d',
-    'source/unit_threaded/tests/parametrized.d',
-    'source/unit_threaded/tests/structs_are_not_classes.d',
-    'source/unit_threaded/tests/tags.d',
-]
+main_sources = run_command('sh', '-c', 'cd $MESON_SOURCE_ROOT && ls source/unit_threaded/*.d').stdout().split()
+randomized_sources = run_command('sh', '-c', 'cd $MESON_SOURCE_ROOT && ls source/unit_threaded/randomized/*.d').stdout().split()
+tests_sources = run_command('sh', '-c', 'cd $MESON_SOURCE_ROOT && ls source/unit_threaded/tests/*.d').stdout().split()
 
 inc_dirs = [
     include_directories('source'),

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,89 @@
+# -*- mode: python; -*-
+
+project(
+    'unit-threaded',
+    'd',
+    version: '0.7.32',
+    default_options: ['buildtype=release'],
+)
+
+main_sources =  [
+    'source/unit_threaded/asserts.d',
+    'source/unit_threaded/attrs.d',
+    'source/unit_threaded/dub.d',
+    'source/unit_threaded/factory.d',
+    'source/unit_threaded/integration.d',
+    'source/unit_threaded/io.d',
+    'source/unit_threaded/light.d',
+    'source/unit_threaded/meta.d',
+    'source/unit_threaded/mock.d',
+    'source/unit_threaded/options.d',
+    'source/unit_threaded/package.d',
+    'source/unit_threaded/property.d',
+    'source/unit_threaded/reflection.d',
+    'source/unit_threaded/runner.d',
+    'source/unit_threaded/runtime.d',
+    'source/unit_threaded/should.d',
+    'source/unit_threaded/testcase.d',
+    'source/unit_threaded/testsuite.d',
+    'source/unit_threaded/uda.d',
+]
+
+randomized_sources = [
+    'source/unit_threaded/randomized/benchmark.d',
+    'source/unit_threaded/randomized/gen.d',
+    'source/unit_threaded/randomized/package.d',
+    'source/unit_threaded/randomized/random.d',
+]
+
+inc_dirs = [
+    include_directories('source'),
+]
+
+shared_library(
+    meson.project_name(),
+    main_sources + randomized_sources,
+    include_directories: inc_dirs,
+    version: meson.project_version(),
+    soversion: '0',
+    install: true,
+)
+
+static_library(
+    meson.project_name(),
+    main_sources + randomized_sources,
+    include_directories: inc_dirs,
+    install: true,
+)
+
+foreach item: main_sources
+    install_data(item, install_dir: get_option('prefix') + '/include/d/unit_threaded')
+endforeach
+
+foreach item: randomized_sources
+    install_data(item, install_dir: get_option('prefix') + '/include/d/unit_threaded/randomized')
+endforeach
+
+# The pkgconfig system produces C/C++ library flags which are of
+# little use with ldc2, so must do things the hard way. :-(
+
+pc_file_data = configuration_data()
+pc_file_data.set('NAME', meson.project_name())
+pc_file_data.set('VERSION', meson.project_version())
+pc_file_data.set('DESCRIPTION', 'Advanced multi-threaded unit testing framework with minimal to no boilerplate using built-in unittest blocks.')
+pc_file_data.set('LIBS', '-L-L${libdir} -L-l' + meson.project_name())
+pc_file_data.set('CFLAGS', '-I${includedir}/d')
+pc_file_data.set('PREFIX', get_option('prefix'))
+pc_file = configure_file(configuration: pc_file_data, input: meson.project_name() + '.pc.in', output: meson.project_name() + '.pc')
+
+install_data(pc_file, install_dir: 'share/pkgconfig')
+
+#testExecutable = executable(
+#    'unit-threaded-test',
+#    main_sources + randomized_sources,
+#    include_directories: inc_dirs,
+#    d_args: ['-unittest'],
+#    link_args: ['--main'],
+#)
+
+#test('all tests', testExecutable)

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
     'unit-threaded',
     'd',
-    version: '0.7.32',
+    version: '0.7.33',
     default_options: ['buildtype=release'],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,7 @@ inc_dirs = [
     include_directories('source'),
 ]
 
-shared_library(
+unit_threaded = shared_library(
     meson.project_name(),
     main_sources + randomized_sources + tests_sources,
     include_directories: inc_dirs,
@@ -91,6 +91,16 @@ pc_file_data.set('PREFIX', get_option('prefix'))
 pc_file = configure_file(configuration: pc_file_data, input: meson.project_name() + '.pc.in', output: meson.project_name() + '.pc')
 
 install_data(pc_file, install_dir: 'share/pkgconfig')
+
+executable(
+    'gen-ut-main',
+    'gen/gen_ut_main.d',
+    include_directories: inc_dirs,
+    link_with: unit_threaded,
+    install: true,
+)
+
+# unit_threaded requires a unity build which Meson cannot do for D as yet (2017-11-10).
 
 #testExecutable = executable(
 #    'unit-threaded-test',

--- a/unit-threaded.pc.in
+++ b/unit-threaded.pc.in
@@ -1,0 +1,9 @@
+prefix=@PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @NAME@
+Description: @DESCRIPTION@
+Version: @VERSION@
+Libs: @LIBS@
+Cflags: @CFLAGS@


### PR DESCRIPTION
I created this Meson build so as to make shared objects of Unit Threaded – this enables having the library installed as GtkD is. I have also done this for DInotify.

Sadly Meson/Ninja do not yet support unity builds for D, so it is not yet possible to build the Unit Threaded tests.

If this facility is not interesting, no worries, I'll just keep it as a personal branch.