### PR TITLE
Update version number in Meson build file.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
     'unit-threaded',
     'd',
-    version: '0.7.33',
+    version: '0.7.36',
     default_options: ['buildtype=release'],
 )
 


### PR DESCRIPTION
It is not clear if there is a way of avoiding having the version number explicitly in the Meson build file: Meson builds have to work outside a Git repository context.