### PR TITLE
Update dub.sdl - mark targetType as an executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ configuration "unittest" {
     dependency "unit-threaded" version="~>0.7.11"
     mainSourceFile "bin/ut.d"
     excludedSourceFiles "src/main.d"
+    targetType "executable"
     preBuildCommands "dub run unit-threaded -c gen_ut_main -- -f bin/ut.d"
 }
 


### PR DESCRIPTION
Before, dub would build the unit-threaded test runner as a library, therefore not actually executing any tests.

This modifies dub.sdl so it builds an executable.