### PR TITLE
run deterministic single-threaded test on ci.dlang.org

### DIFF
--- a/integration/run.sh
+++ b/integration/run.sh
@@ -3,6 +3,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DC="${DC:-dmd}"
+if [ "${DETERMINISTIC_HINT:-0}" -eq 1 ]; then
+    ARGS=(--single)
+else
+    ARGS=()
+fi
 
-cd $SCRIPT_DIR/issue61
-dub run --build=unittest-cov
+cd "$SCRIPT_DIR/issue61"
+dub run --build=unittest-cov --compiler="$DC" -- "${ARGS[@]}"

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,12 @@
 set -euo pipefail
 
 DC="${DC:-dmd}"
-dub test --build=unittest-cov
-dub run -c unittest-unthreaded --build=unittest-cov --compiler="$DC"
+if [ "${DETERMINISTIC_HINT:-0}" -eq 1 ]; then
+    ARGS=(--single)
+else
+    ARGS=()
+fi
+dub test --build=unittest-cov --compiler="$DC" -- "${ARGS[@]}"
+dub run -c unittest-unthreaded --build=unittest-cov --compiler="$DC" -- "${ARGS[@]}"
 # See issue #96
-#dub run -c unittest-light --build=unittest
+#dub run -c unittest-light --build=unittest -- "${ARGS[@]}"


### PR DESCRIPTION
- by obeying DETERMINISTIC_HINT=1
- also unify handling of env vars and fix shellcheck issues