### PR TITLE
Fix some doc details

### DIFF
--- a/source/unit_threaded/randomized/benchmark.d
+++ b/source/unit_threaded/randomized/benchmark.d
@@ -119,7 +119,7 @@ struct Benchmark
     Params:
         funcname = The name of the $(D benchmark) instance. The $(D funcname)
             will be used to associate the results with the function
-        founds = How many rounds.
+        rounds = How many rounds.
         filename = The $(D filename) will be used as a filename to store the
             results.
     */
@@ -244,9 +244,6 @@ Params:
         save the benchmark results.
     maxRuntime = The maximum time the benchmark is executed. The last run will
         not be interrupted.
-    rndSeed = The seed to the random number generator used to populate the
-        parameter passed to the function to benchmark.
-    rounds = The maximum number of times the callable $(D T) is called.
 */
 void benchmark(alias T)(const ref BenchmarkOptions opts)
 {
@@ -308,14 +305,6 @@ void benchmark(alias T)(from!"std.datetime".Duration maxRuntime, string filename
 }
 
 /// Ditto
-/*void benchmark(alias T)(string name, string filename = __FILE__)
-{
-    auto opt = BenchmarkOptions(name);
-    opt.filename = filename;
-    benchmark!(T)(opt);
-}*/
-
-/// Ditto
 void benchmark(alias T)(string name, from!"std.datetime".Duration maxRuntime,
     string filename = __FILE__)
 {
@@ -324,3 +313,11 @@ void benchmark(alias T)(string name, from!"std.datetime".Duration maxRuntime,
     opt.duration = maxRuntime;
     benchmark!(T)(opt);
 }
+
+/// Ditto
+/*void benchmark(alias T)(string name, string filename = __FILE__)
+{
+    auto opt = BenchmarkOptions(name);
+    opt.filename = filename;
+    benchmark!(T)(opt);
+}*/

--- a/source/unit_threaded/runtime.d
+++ b/source/unit_threaded/runtime.d
@@ -30,9 +30,9 @@ command-line options.
 
 Examples (assuming the generated file is called $(D ut.d)):
 -----
-rdmd -unittest ut.d # run all tests
-rdmd -unittest ut.d tests.foo tests.bar # run all tests from these packages
-rdmd ut.d -h # list command-line options
+rdmd -unittest ut.d // run all tests
+rdmd -unittest ut.d tests.foo tests.bar // run all tests from these packages
+rdmd ut.d -h // list command-line options
 -----
 */
 


### PR DESCRIPTION
Building with dub and ddox seems to want to parse all the docs in libraries that are not yours as well :/ 
So was getting this when running `dub build -b ddox` in me own libs.
```
➜ dub build -b ddox
Performing "ddox" build using dmd for x86_64.
unit-threaded 0.7.46+commit.11.g3794ea2: building configuration "library"...
source/unit_threaded/randomized/benchmark.d(126,5): Warning: Ddoc: function declaration has no parameter 'founds'
source/unit_threaded/randomized/benchmark.d(251,6): Warning: Ddoc: function declaration has no parameter 'name'
source/unit_threaded/randomized/benchmark.d(251,6): Warning: Ddoc: function declaration has no parameter 'rndSeed'
source/unit_threaded/randomized/benchmark.d(251,6): Warning: Ddoc: function declaration has no parameter 'rounds'
```