### PR TITLE
remove isInputRange check constraits on isEqual

### DIFF
--- a/source/unit_threaded/should.d
+++ b/source/unit_threaded/should.d
@@ -554,7 +554,6 @@ private enum isObject(T) = is(T == class) || is(T == interface);
 
 bool isEqual(V, E)(in auto ref V value, in auto ref E expected)
  if (!isObject!V &&
-     (!isInputRange!V || !isInputRange!E) &&
      !isFloatingPoint!V && !isFloatingPoint!E &&
      is(typeof(value == expected) == bool))
 {

--- a/tests/unit_threaded/ut/should.d
+++ b/tests/unit_threaded/ut/should.d
@@ -103,6 +103,11 @@ private void assertFail(E)(lazy E expression, in string file = __FILE__, in size
     shouldNotEqual([1 : 2.0, 2 : 4.0], [1 : 2.2, 2 : 4.0]) ;
 }
 
+@safe unittest {
+    import std.algorithm: map;
+    const constRange = [1, 2, 3].map!"a";
+    shouldEqual(constRange, constRange);
+}
 
 @safe pure unittest
 {


### PR DESCRIPTION
In the function `isEqual(V, E)(in auto ref V value, in auto ref E expected)`, `in` is just const. So when V and E are const(Range), the `in` pattern matches const part, so then (!isInputRange!V || !isInputRange!E) evaluates to false. So this overload fails. But then the overloads that expect an input range also fail because they do not strip out the const and a const range is not an input range.

I removed the `in` on isEqual and then compiling this case works, but unfortunately you then get errors in your test suite when you try and call isEqual on `int[int]` and `const(int[int])` for e.g.

So I figured if is(typeof(a == b) == bool) works and it's a value type and not float it should be good?