### PR TITLE
Don't repeat from template

### DIFF
--- a/source/unit_threaded/property.d
+++ b/source/unit_threaded/property.d
@@ -3,11 +3,7 @@
  */
 module unit_threaded.property;
 
-
-template from(string moduleName) {
-    mixin("import from = " ~ moduleName ~ ";");
-}
-
+import unit_threaded.from;
 
 ///
 class PropertyException : Exception

--- a/source/unit_threaded/randomized/gen.d
+++ b/source/unit_threaded/randomized/gen.d
@@ -1,9 +1,6 @@
 module unit_threaded.randomized.gen;
 
-template from(string moduleName) {
-    mixin("import from = " ~ moduleName ~ ";");
-}
-
+import unit_threaded.from;
 
 /* Return $(D true) if the passed $(D T) is a $(D Gen) struct.
 


### PR DESCRIPTION
Was also publicly imported from property.d, which is publicly imported
from unit_threaded.package, which means anyone importing unit_threaded
who has their own implementation of "from" will have problems.