### PR TITLE
The gen-ut-main executable must link to the compilers runtime system,…

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ executable(
     'gen/gen_ut_main.d',
     include_directories: include_dirs,
     link_with: lib,
+    link_args: ['-link-defaultlib-shared'],
     install: true,
 )
 


### PR DESCRIPTION
… hence this flag.