### PR TITLE
Fix running tests on Windows.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -39,7 +39,6 @@
             "targetName": "ut_pass",
             "sourcePaths": ["source", "gen/source", "tests/unit_threaded", "tests/examples/pass"],
             "importPaths": ["source"],
-            "sourceFiles": ["example/example_pass.d"],
             "mainSourceFile": "example/example_pass.d",
             "dflags": ["-dip25", "-dip1000", "-dip1008"],
             "versions": ["testing_unit_threaded"]
@@ -49,7 +48,6 @@
             "targetType": "executable",
             "targetName": "ut_pass",
             "sourcePaths": ["source", "gen/source", "tests/unit_threaded", "tests/examples/pass"],
-            "sourceFiles": ["example/example_pass.d"],
             "mainSourceFile": "example/example_pass.d",
             "versions": ["testing_unit_threaded", "unitUnthreaded"]
         },
@@ -59,7 +57,6 @@
             "targetType": "executable",
             "targetName": "ut_pass",
             "sourcePaths": ["source", "gen/source", "tests/unit_threaded", "tests/examples/pass"],
-            "sourceFiles": ["example/example_pass.d"],
             "mainSourceFile": "example/example_pass.d",
             "dflags": ["-dip25", "-dip1000", "-dip1008"],
             "versions": ["testing_unit_threaded", "unitThreadedLight", "unitUnthreaded"]
@@ -70,7 +67,6 @@
             "targetType": "executable",
             "targetName": "ut_fail",
             "sourcePaths": ["tests/examples/pass", "tests/examples/fail/"],
-            "sourceFiles": ["example/example_fail.d"],
             "mainSourceFile": "example/example_fail.d",
             "versions": ["testing_unit_threaded"]
         },


### PR DESCRIPTION
Dub adds the `mainSourceFile` to `sourceFiles`, so including `example_pass.d` twice is unnecessary.

With the duplication, attempting to build any of the test configurations on Windows yields the error "Error: module 'example_pass' from file example\example_pass.d is specified twice on the command line" due to [dub bug 1454](https://github.com/dlang/dub/issues/1454). 