### PR TITLE
don't escape exceptions : fix for dip1008 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@ sudo: false
 
 matrix:
   include:
+    - d: dmd-nightly
+    - d: dmd-2.086.1
     - d: dmd-2.085.0
     - d: dmd-2.084.1
+    - d: ldc-1.16.0
+    - d: ldc-1.15.0
     - d: ldc-1.14.0
     - d: ldc-1.13.0
-
+  allow_failures:
+    - d: dmd-nightly
 
 script:
   - build/ci.sh

--- a/subpackages/assertions/source/unit_threaded/assertions.d
+++ b/subpackages/assertions/source/unit_threaded/assertions.d
@@ -441,13 +441,16 @@ private auto threw(T : Throwable, E)(lazy E expr)
     import std.typecons : tuple;
 
     auto ret = tuple!("threw", "info")(false, ThrownInfo!T.init);
+
+    // separate in order to not be inside the @trusted
     void makeRet(scope T e) {
         ret = typeof(ret)(true, ThrownInfo!T(typeid(e), e.msg.dup));
     }
+    // insert dummy call outside @trusted to correctly infer the attributes of shouldThrow
     if (false)
         makeRet(null);
 
-    (() @trusted {
+    (() @trusted { // @trusted because of catching Throwable
         try
             expr();
         catch (T e)

--- a/tests/unit_threaded/ut/should.d
+++ b/tests/unit_threaded/ut/should.d
@@ -282,6 +282,18 @@ unittest {
     assertFail(func.shouldThrowWithMessage("oops"));
 }
 
+@("catch Throwables without compromising other safety checks")
+unittest
+{
+    int a  = 3;
+    void foo() @system { assert(a == 4); }
+    void bar() @safe { assert(a == 4); }
+    static assert(!__traits(compiles, () @safe => foo.shouldThrow!Throwable));
+    static assert(__traits(compiles, () => foo.shouldThrow!Throwable));
+    static assert(__traits(compiles, () @safe => bar.shouldThrow!Throwable));
+    static assert(__traits(compiles, () => bar.shouldThrow!Throwable));
+}
+
 // can't be made pure because of throwExactly, which in turn
 // can't be pure because of Object.opEquals
 @safe unittest

--- a/tests/unit_threaded/ut/should.d
+++ b/tests/unit_threaded/ut/should.d
@@ -238,8 +238,8 @@ private void assertFail(E)(lazy E expression, in string file = __FILE__, in size
     import unit_threaded.asserts;
     void funcThrows(string msg) { throw new Exception(msg); }
     try {
-        auto exception = funcThrows("foo bar").shouldThrow;
-        assertEqual(exception.msg, "foo bar");
+        auto exceptionInfo = funcThrows("foo bar").shouldThrow;
+        assertEqual(exceptionInfo.msg, "foo bar");
     } catch(Exception e) {
         assert(false, "should not have thrown anything and threw: " ~ e.msg);
     }


### PR DESCRIPTION
You can't safely escape them, you can't copy them, you can only leak references to them without noticing because of https://issues.dlang.org/show_bug.cgi?id=20023 AARRGGGHH

This is a breaking change because it changes the return type of `shouldThrow` and `shouldThrowExactly`.

you can see the failure on updating the compilers in the CI without the rest of my changes here: https://travis-ci.org/atilaneves/unit-threaded/builds/553893532?utm_source=github_status&utm_medium=notification