### PR TITLE
use dub variables and --compiler passthrough in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ project, you can use a `unittest` configuration as exemplified in this
         {
             "name": "unittest",
             "targetType": "executable",
-            "preBuildCommands": ["dub run unit-threaded -c gen_ut_main -- -f bin/ut.d"],
+            "preBuildCommands": ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"],
             "mainSourceFile": "bin/ut.d",
             "excludedSourceFiles": ["src/main.d"],
             "dependencies": {
@@ -61,7 +61,7 @@ configuration "unittest" {
     mainSourceFile "bin/ut.d"
     excludedSourceFiles "src/main.d"
     targetType "executable"
-    preBuildCommands "dub run unit-threaded -c gen_ut_main -- -f bin/ut.d"
+    preBuildCommands "$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"
 }
 
 ```
@@ -97,7 +97,7 @@ the standard D runtime unittest runner and one that uses unit-threaded:
         {"name": "ut_default"},
         {
           "name": "unittest",
-          "preBuildCommands: ["dub run unit-threaded -c gen_ut_main -- -f bin/ut.d"],
+          "preBuildCommands: ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"],
           "mainSourceFile": "bin/ut.d",
           ...
         }


### PR DESCRIPTION
`preBuildCommand` recursion with "dub" alone uses the default compiler and dub from the path, causing issues if a different version of dub or the compiler was selected. Instead, pass them through to the nested run.

The `$$DC` is because DC is an environment variable that dub sets only after it has performed its own internal variable expansion. (This is terrible, but what can you do.)