### PR TITLE
Allow more than 26 temporary directories on Windows

### DIFF
--- a/subpackages/integration/source/unit_threaded/integration.d
+++ b/subpackages/integration/source/unit_threaded/integration.d
@@ -23,6 +23,20 @@ version(Windows) {
     }
 
     char* mkdtempImpl(char* t) {
+        // mktemp can actually only return up to 26 unique names per
+        // the documentation at MSDN. To hack around this, I am just
+        // putting in some random letters at some YYYYYY defined below
+        // to make conflicts less likely.
+
+        import core.stdc.string : strstr;
+        import core.stdc.stdlib : rand;
+
+        char* where = strstr(t, "YYYYYY");
+        assert(where !is null);
+        while(*where == 'Y') {
+                *where++ = rand() % 26 + 'A';
+        }
+
         char* result = mktemp(t);
 
         if(result is null) return null;
@@ -237,7 +251,10 @@ private:
         import core.stdc.errno: errno;
 
         char[2048] template_;
-        copy(buildPath(sandboxesPath, "XXXXXX") ~ '\0', template_[]);
+        // the YYYYYY is to give some randomness on systems
+        // where it is necessary to have more than 26 items
+        // harmless elsewhere; the name is random stuff anyway
+        copy(buildPath(sandboxesPath, "YYYYYYXXXXXX") ~ '\0', template_[]);
 
         auto path = () @trusted { return mkdtemp(&template_[0]).to!string; }();
 


### PR DESCRIPTION
The current implementation using mktemp sets five of the Xs
to the thread ID, and only uses the other letter in sequence.
This limits it to 26 directories per template. This change
throws in additional randomness in the template in an effort
to expand that limit, more like we have on Linux, while still
using mktemp for the actual final name.

pls eyeball this for me and make sure i didn't do anything stupid, but it sees to work on my box