### PR TITLE
Pass through compiler and dub binaries to gen_ut_main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ project, you can use a `unittest` configuration as exemplified in this
         {
             "name": "unittest",
             "targetType": "executable",
-            "preBuildCommands": ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"],
+            "preBuildCommands": ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d -d $DUB"],
             "mainSourceFile": "bin/ut.d",
             "excludedSourceFiles": ["src/main.d"],
             "dependencies": {
@@ -61,7 +61,7 @@ configuration "unittest" {
     mainSourceFile "bin/ut.d"
     excludedSourceFiles "src/main.d"
     targetType "executable"
-    preBuildCommands "$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"
+    preBuildCommands "$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d -d $DUB"
 }
 
 ```
@@ -103,7 +103,7 @@ the standard D runtime unittest runner and one that uses unit-threaded:
         {"name": "ut_default"},
         {
           "name": "unittest",
-          "preBuildCommands: ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"],
+          "preBuildCommands: ["$DUB run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d -d $DUB"],
           "mainSourceFile": "bin/ut.d",
           ...
         }

--- a/gen/source/unit_threaded/runtime/runtime.d
+++ b/gen/source/unit_threaded/runtime/runtime.d
@@ -60,6 +60,7 @@ struct Options {
     bool verbose;
     string fileName;
     string[] dirs;
+    string dubBinary;
     bool help;
     bool showVersion;
     string[] includes;
@@ -73,6 +74,7 @@ struct Options {
 
 Options getGenUtOptions(string[] args) {
     import std.getopt;
+    import std.range: empty;
     import std.stdio: writeln;
 
     Options options;
@@ -80,6 +82,7 @@ Options getGenUtOptions(string[] args) {
         args,
         "verbose|v", "Verbose mode.", &options.verbose,
         "file|f", "The filename to write. Will use a temporary if not set.", &options.fileName,
+        "dub|d", "The dub binary to use.", &options.dubBinary,
         "I", "Import paths as would be passed to the compiler", &options.includes,
         "version", "Show version.", &options.showVersion,
         );
@@ -99,6 +102,10 @@ Options getGenUtOptions(string[] args) {
 
     if (options.verbose) {
         writeln(__FILE__, ": finding all test cases in ", options.dirs);
+    }
+
+    if (options.dubBinary.empty) {
+        options.dubBinary = "dub";
     }
 
     return options;


### PR DESCRIPTION
This avoids issues with `dub describe` when no system `dub` and `dmd` binaries are available.

Jesus, that command line just keeps getting worse... Dub *really* wants dub/dmd to be in `PATH`.