### PR TITLE
Use wb mode in writeFile

### DIFF
--- a/subpackages/integration/source/unit_threaded/integration.d
+++ b/subpackages/integration/source/unit_threaded/integration.d
@@ -97,7 +97,7 @@ struct Sandbox {
         import std.file: mkdirRecurse;
 
         () @trusted { mkdirRecurse(buildPath(testPath, fileName.dirName)); }();
-        File(buildPath(testPath, fileName), "w").writeln(output);
+        File(buildPath(testPath, fileName), "wb").writeln(output);
     }
 
     /// Write a file to the sanbox

--- a/tests/unit_threaded/ut/integration.d
+++ b/tests/unit_threaded/ut/integration.d
@@ -82,3 +82,12 @@ import unit_threaded.integration;
         shouldEqualLines("lines.txt", ["foo", "toto"]);
     }
 }
+
+version(Windows) {
+    @safe unittest {
+        with(immutable Sandbox()) {
+            writeFile("newline.txt", "\r\n");
+            shouldEqualContent("newline.txt", "\r\n\n");
+        }
+    }
+}


### PR DESCRIPTION
Using `wb` File mode prevents conversion from CRLF to CRCRLF.
Related issue #143