### PR TITLE
Update Meson build version to match tagged version number.

### DIFF
--- a/build/meson.build
+++ b/build/meson.build
@@ -3,7 +3,7 @@
 project(
     'unit-threaded',
     'd',
-    version: '1.0.2',
+    version: '1.0.4',
     meson_version: '>=0.48',
     default_options: ['buildtype=release'],
 )


### PR DESCRIPTION
build/meson.build has version number 1.0.2, updated here to 1.0.4.