### PR TITLE
Fix 218 - Support DMD v2.094.0's `-preview=in` switch

### DIFF
--- a/source/unit_threaded/light.d
+++ b/source/unit_threaded/light.d
@@ -75,7 +75,7 @@ void writelnUt(T...)(auto ref T args) {
    Same as unit_threaded.property.check
  */
 void check(alias F)(int numFuncCalls = 100,
-                    in string file = __FILE__, in size_t line = __LINE__) {
+                    string file = __FILE__, size_t line = __LINE__) {
     import unit_threaded.property: utCheck = check;
     utCheck!F(numFuncCalls, file, line);
 }
@@ -84,7 +84,7 @@ void check(alias F)(int numFuncCalls = 100,
    Same as unit_threaded.property.checkCustom
  */
 void checkCustom(alias Generator, alias Predicate)
-                (int numFuncCalls = 100, in string file = __FILE__, in size_t line = __LINE__) {
+                (int numFuncCalls = 100, string file = __FILE__, size_t line = __LINE__) {
     import unit_threaded.property: utCheckCustom = checkCustom;
     utCheckCustom!(Generator, Predicate)(numFuncCalls, file, line);
 }
@@ -129,17 +129,17 @@ auto mockStruct(T...)(auto ref T returns) {
 /**
    Throw if condition is not true.
  */
-void shouldBeTrue(E)(lazy E condition, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeTrue(E)(lazy E condition, string file = __FILE__, size_t line = __LINE__) {
     assert_(cast(bool)condition(), file, line);
 }
 
 /// Throw if condition not false.
-void shouldBeFalse(E)(lazy E condition, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeFalse(E)(lazy E condition, string file = __FILE__, size_t line = __LINE__) {
     assert_(!cast(bool)condition(), file, line);
 }
 
 /// Assert value is equal to expected
-void shouldEqual(V, E)(auto ref V value, auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldEqual(V, E)(auto ref V value, auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
 
     void checkInputRange(T)(auto ref const(T) _) @trusted {
         auto obj = cast(T) _;
@@ -203,17 +203,17 @@ void shouldEqual(V, E)(auto ref V value, auto ref E expected, in string file = _
 
 
 /// Assert value is not equal to expected.
-void shouldNotEqual(V, E)(in auto ref V value, in auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotEqual(V, E)(in auto ref V value, in auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
     assert_(value != expected, file, line);
 }
 
 /// Assert value is null.
-void shouldBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__) {
     assert_(value is null, file, line);
 }
 
 /// Assert value is not null
-void shouldNotBeNull(T)(in auto ref T value, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__) {
     assert_(value !is null, file, line);
 }
 
@@ -226,13 +226,13 @@ static assert(!isLikeAssociativeArray!(string[string], int));
 
 
 /// Assert that value is in container.
-void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, size_t line = __LINE__)
     if(isLikeAssociativeArray!(U, T)) {
     assert_(cast(bool)(value in container), file, line);
 }
 
 /// ditto.
-void shouldBeIn(T, U)(in auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T))
 {
     import std.algorithm: find;
@@ -241,13 +241,13 @@ void shouldBeIn(T, U)(in auto ref T value, U container, in string file = __FILE_
 }
 
 /// Assert value is not in container.
-void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, size_t line = __LINE__)
     if(isLikeAssociativeArray!U) {
     assert_(!cast(bool)(value in container), file, line);
 }
 
 /// ditto.
-void shouldNotBeIn(T, U)(in auto ref T value, U container, in string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T))
 {
     import std.algorithm: find;
@@ -257,7 +257,7 @@ void shouldNotBeIn(T, U)(in auto ref T value, U container, in string file = __FI
 
 /// Assert that expr throws.
 void shouldThrow(T : Throwable = Exception, E)
-                (lazy E expr, in string file = __FILE__, in size_t line = __LINE__) {
+                (lazy E expr, string file = __FILE__, size_t line = __LINE__) {
     import std.traits: isSafe, isUnsafe;
 
     auto threw = false;
@@ -286,7 +286,7 @@ void shouldThrow(T : Throwable = Exception, E)
 
 /// Assert that expr throws an Exception that must have the type E, derived types won't do.
 void shouldThrowExactly(T : Throwable = Exception, E)
-                       (lazy E expr, in string file = __FILE__, in size_t line = __LINE__)
+                       (lazy E expr, string file = __FILE__, size_t line = __LINE__)
 {
     import std.traits: isSafe, isUnsafe;
 
@@ -318,7 +318,7 @@ void shouldThrowExactly(T : Throwable = Exception, E)
 
 /// Assert that expr doesn't throw
 void shouldNotThrow(T: Throwable = Exception, E)
-                   (lazy E expr, in string file = __FILE__, in size_t line = __LINE__) {
+                   (lazy E expr, string file = __FILE__, size_t line = __LINE__) {
 
     import std.traits: isSafe, isUnsafe;
 
@@ -380,7 +380,7 @@ void shouldApproxEqual(V, E)
 }
 
 /// assert that rng is empty.
-void shouldBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = __LINE__) {
     import std.range: isInputRange;
     import std.traits: isAssociativeArray;
     import std.array;
@@ -394,7 +394,7 @@ void shouldBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t li
 }
 
 /// Assert that rng is not empty.
-void shouldNotBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = __LINE__) {
     import std.range: isInputRange;
     import std.traits: isAssociativeArray;
     import std.array;
@@ -409,25 +409,25 @@ void shouldNotBeEmpty(R)(in auto ref R rng, in string file = __FILE__, in size_t
 
 /// Assert that t should be greater than u.
 void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
-                               in string file = __FILE__, in size_t line = __LINE__)
+                               string file = __FILE__, size_t line = __LINE__)
 {
     assert_(t > u, file, line);
 }
 
 /// Assert that t should be smaller than u.
 void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
-                               in string file = __FILE__, in size_t line = __LINE__)
+                               string file = __FILE__, size_t line = __LINE__)
 {
     assert_(t < u, file, line);
 }
 
 /// Assert that value is the same set as expected (i.e. order doesn't matter)
-void shouldBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
     assert_(isSameSet(value, expected), file, line);
 }
 
 /// Assert that value is not the same set as expected.
-void shouldNotBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, in string file = __FILE__, in size_t line = __LINE__) {
+void shouldNotBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
     assert_(!isSameSet(value, expected), file, line);
 }
 
@@ -451,8 +451,8 @@ private bool isSameSet(T, U)(in auto ref T t, in auto ref U u) {
 /// Assert that actual and expected represent the same JSON (i.e. formatting doesn't matter)
 void shouldBeSameJsonAs(in string actual,
                         in string expected,
-                        in string file = __FILE__,
-                        in size_t line = __LINE__)
+                        string file = __FILE__,
+                        size_t line = __LINE__)
     @trusted // not @safe pure due to parseJSON
 {
     import std.json: parseJSON, JSONException;
@@ -470,16 +470,16 @@ void shouldBeSameJsonAs(in string actual,
 }
 
 
-private void assert_(in bool value, in string file, in size_t line) @safe pure {
+private void assert_(in bool value, string file, size_t line) @safe pure {
     assert_(value, "Assertion failure", file, line);
 }
 
-private void assert_(bool value, in string message, in string file, in size_t line) @safe pure {
+private void assert_(bool value, string message, string file, size_t line) @safe pure {
     if(!value)
         throw new Exception(message, file, line);
 }
 
-void fail(in string output, in string file, in size_t line) @safe pure {
+void fail(in string output, string file, size_t line) @safe pure {
     assert_(false, output, file, line);
 }
 
@@ -489,8 +489,8 @@ auto should(E)(lazy E expr) {
     struct Should {
 
         bool opEquals(U)(auto ref U other,
-                         in string file = __FILE__,
-                         in size_t line = __LINE__)
+                         string file = __FILE__,
+                         size_t line = __LINE__)
         {
             expr.shouldEqual(other, file, line);
             return true;

--- a/source/unit_threaded/light.d
+++ b/source/unit_threaded/light.d
@@ -203,17 +203,17 @@ void shouldEqual(V, E)(auto ref V value, auto ref E expected, string file = __FI
 
 
 /// Assert value is not equal to expected.
-void shouldNotEqual(V, E)(in auto ref V value, in auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
+void shouldNotEqual(V, E)(const scope auto ref V value, const scope auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
     assert_(value != expected, file, line);
 }
 
 /// Assert value is null.
-void shouldBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__) {
+void shouldBeNull(T)(const scope auto ref T value, string file = __FILE__, size_t line = __LINE__) {
     assert_(value is null, file, line);
 }
 
 /// Assert value is not null
-void shouldNotBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__) {
+void shouldNotBeNull(T)(const scope auto ref T value, string file = __FILE__, size_t line = __LINE__) {
     assert_(value !is null, file, line);
 }
 
@@ -226,13 +226,13 @@ static assert(!isLikeAssociativeArray!(string[string], int));
 
 
 /// Assert that value is in container.
-void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, size_t line = __LINE__)
+void shouldBeIn(T, U)(const scope auto ref T value, const scope auto ref U container, string file = __FILE__, size_t line = __LINE__)
     if(isLikeAssociativeArray!(U, T)) {
     assert_(cast(bool)(value in container), file, line);
 }
 
 /// ditto.
-void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
+void shouldBeIn(T, U)(const scope auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T))
 {
     import std.algorithm: find;
@@ -241,13 +241,13 @@ void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, 
 }
 
 /// Assert value is not in container.
-void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, size_t line = __LINE__)
+void shouldNotBeIn(T, U)(const scope auto ref T value, const scope auto ref U container, string file = __FILE__, size_t line = __LINE__)
     if(isLikeAssociativeArray!U) {
     assert_(!cast(bool)(value in container), file, line);
 }
 
 /// ditto.
-void shouldNotBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
+void shouldNotBeIn(T, U)(const scope auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T))
 {
     import std.algorithm: find;
@@ -380,7 +380,7 @@ void shouldApproxEqual(V, E)
 }
 
 /// assert that rng is empty.
-void shouldBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = __LINE__) {
+void shouldBeEmpty(R)(const scope auto ref R rng, string file = __FILE__, size_t line = __LINE__) {
     import std.range: isInputRange;
     import std.traits: isAssociativeArray;
     import std.array;
@@ -394,7 +394,7 @@ void shouldBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = _
 }
 
 /// Assert that rng is not empty.
-void shouldNotBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = __LINE__) {
+void shouldNotBeEmpty(R)(const scope auto ref R rng, string file = __FILE__, size_t line = __LINE__) {
     import std.range: isInputRange;
     import std.traits: isAssociativeArray;
     import std.array;
@@ -408,30 +408,30 @@ void shouldNotBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line 
 }
 
 /// Assert that t should be greater than u.
-void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeGreaterThan(T, U)(const scope auto ref T t, const scope auto ref U u,
                                string file = __FILE__, size_t line = __LINE__)
 {
     assert_(t > u, file, line);
 }
 
 /// Assert that t should be smaller than u.
-void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeSmallerThan(T, U)(const scope auto ref T t, const scope auto ref U u,
                                string file = __FILE__, size_t line = __LINE__)
 {
     assert_(t < u, file, line);
 }
 
 /// Assert that value is the same set as expected (i.e. order doesn't matter)
-void shouldBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
+void shouldBeSameSetAs(V, E)(const scope auto ref V value, const scope auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
     assert_(isSameSet(value, expected), file, line);
 }
 
 /// Assert that value is not the same set as expected.
-void shouldNotBeSameSetAs(V, E)(in auto ref V value, in auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
+void shouldNotBeSameSetAs(V, E)(const scope auto ref V value, const scope auto ref E expected, string file = __FILE__, size_t line = __LINE__) {
     assert_(!isSameSet(value, expected), file, line);
 }
 
-private bool isSameSet(T, U)(in auto ref T t, in auto ref U u) {
+private bool isSameSet(T, U)(const scope auto ref T t, const scope auto ref U u) {
     import std.array: array;
     import std.algorithm: canFind;
 

--- a/subpackages/assertions/source/unit_threaded/assertions.d
+++ b/subpackages/assertions/source/unit_threaded/assertions.d
@@ -114,7 +114,7 @@ void shouldNotEqual(V, E)
  * Verify that the value is null.
  * Throws: UnitTestException on failure
  */
-void shouldBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__)
+void shouldBeNull(T)(const scope auto ref T value, string file = __FILE__, size_t line = __LINE__)
 {
     if (value !is null)
         fail("Value is not null", file, line);
@@ -131,7 +131,7 @@ void shouldBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = 
  * Verify that the value is not null.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__)
+void shouldNotBeNull(T)(const scope auto ref T value, string file = __FILE__, size_t line = __LINE__)
 {
     if (value is null)
         fail("Value is null", file, line);
@@ -167,7 +167,7 @@ static assert(!isLikeAssociativeArray!(string[string], int));
  * Verify that the value is in the container.
  * Throws: UnitTestException on failure
 */
-void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, size_t line = __LINE__)
+void shouldBeIn(T, U)(const scope auto ref T value, const scope auto ref U container, string file = __FILE__, size_t line = __LINE__)
     if (isLikeAssociativeArray!(U, T))
 {
     import std.conv: to;
@@ -197,7 +197,7 @@ void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file 
  * Verify that the value is in the container.
  * Throws: UnitTestException on failure
  */
-void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
+void shouldBeIn(T, U)(const scope auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T) && isInputRange!U)
 {
     import std.algorithm: find;
@@ -222,7 +222,7 @@ void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, 
  * Verify that the value is not in the container.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container,
+void shouldNotBeIn(T, U)(const scope auto ref T value, const scope auto ref U container,
                          string file = __FILE__, size_t line = __LINE__)
     if (isLikeAssociativeArray!(U, T))
 {
@@ -254,7 +254,7 @@ void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container,
  * Verify that the value is not in the container.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeIn(T, U)(in auto ref T value, U container,
+void shouldNotBeIn(T, U)(const scope auto ref T value, U container,
                          string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T) && isInputRange!U)
 {
@@ -693,7 +693,7 @@ bool isEqual(V, E)(scope V value, scope E expected)
  * Verify that rng is empty.
  * Throws: UnitTestException on failure.
  */
-void shouldBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = __LINE__)
+void shouldBeEmpty(R)(const scope auto ref R rng, string file = __FILE__, size_t line = __LINE__)
 if (isInputRange!R)
 {
     import std.conv: text;
@@ -757,7 +757,7 @@ if (isInputRange!R)
  * Verify that aa is not empty.
  * Throws: UnitTestException on failure.
  */
-void shouldNotBeEmpty(T)(in auto ref T aa, string file = __FILE__, size_t line = __LINE__)
+void shouldNotBeEmpty(T)(const scope auto ref T aa, string file = __FILE__, size_t line = __LINE__)
 if (isAssociativeArray!T)
 {
     //keys is @system
@@ -785,7 +785,7 @@ if (isAssociativeArray!T)
  * Verify that t is greater than u.
  * Throws: UnitTestException on failure.
  */
-void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeGreaterThan(T, U)(const scope auto ref T t, const scope auto ref U u,
                                string file = __FILE__, size_t line = __LINE__)
 {
     import std.conv: text;
@@ -804,7 +804,7 @@ void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
  * Verify that t is smaller than u.
  * Throws: UnitTestException on failure.
  */
-void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
+void shouldBeSmallerThan(T, U)(const scope auto ref T t, const scope auto ref U u,
                                string file = __FILE__, size_t line = __LINE__)
 {
     import std.conv: text;

--- a/subpackages/assertions/source/unit_threaded/assertions.d
+++ b/subpackages/assertions/source/unit_threaded/assertions.d
@@ -15,7 +15,7 @@ import std.range; // also
  * Verify that the condition is `true`.
  * Throws: UnitTestException on failure.
  */
-void shouldBeTrue(E)(lazy E condition, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeTrue(E)(lazy E condition, string file = __FILE__, size_t line = __LINE__)
 {
     shouldEqual(cast(bool)condition, true, file, line);
 }
@@ -31,7 +31,7 @@ void shouldBeTrue(E)(lazy E condition, string file = __FILE__, in size_t line = 
  * Verify that the condition is `false`.
  * Throws: UnitTestException on failure.
  */
-void shouldBeFalse(E)(lazy E condition, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeFalse(E)(lazy E condition, string file = __FILE__, size_t line = __LINE__)
 {
     shouldEqual(cast(bool)condition, false, file, line);
 }
@@ -47,7 +47,7 @@ void shouldBeFalse(E)(lazy E condition, string file = __FILE__, in size_t line =
  * Verify that two values are the same.
  * Throws: UnitTestException on failure
  */
-void shouldEqual(V, E)(scope auto ref V value, scope auto ref E expected, string file = __FILE__, in size_t line = __LINE__)
+void shouldEqual(V, E)(scope auto ref V value, scope auto ref E expected, string file = __FILE__, size_t line = __LINE__)
 {
     if (!isEqual(value, expected))
     {
@@ -81,7 +81,7 @@ void shouldNotEqual(V, E)
                    (scope auto ref V value,
                     scope auto ref E expected,
                     string file = __FILE__,
-                    in size_t line = __LINE__)
+                    size_t line = __LINE__)
 {
     if (isEqual(value, expected))
     {
@@ -114,7 +114,7 @@ void shouldNotEqual(V, E)
  * Verify that the value is null.
  * Throws: UnitTestException on failure
  */
-void shouldBeNull(T)(in auto ref T value, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__)
 {
     if (value !is null)
         fail("Value is not null", file, line);
@@ -131,7 +131,7 @@ void shouldBeNull(T)(in auto ref T value, string file = __FILE__, in size_t line
  * Verify that the value is not null.
  * Throws: UnitTestException on failure
  */
-void shouldNotBeNull(T)(in auto ref T value, string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeNull(T)(in auto ref T value, string file = __FILE__, size_t line = __LINE__)
 {
     if (value is null)
         fail("Value is null", file, line);
@@ -167,7 +167,7 @@ static assert(!isLikeAssociativeArray!(string[string], int));
  * Verify that the value is in the container.
  * Throws: UnitTestException on failure
 */
-void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file = __FILE__, size_t line = __LINE__)
     if (isLikeAssociativeArray!(U, T))
 {
     import std.conv: to;
@@ -197,7 +197,7 @@ void shouldBeIn(T, U)(in auto ref T value, in auto ref U container, string file 
  * Verify that the value is in the container.
  * Throws: UnitTestException on failure
  */
-void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T) && isInputRange!U)
 {
     import std.algorithm: find;
@@ -223,7 +223,7 @@ void shouldBeIn(T, U)(in auto ref T value, U container, string file = __FILE__, 
  * Throws: UnitTestException on failure
  */
 void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container,
-                         string file = __FILE__, in size_t line = __LINE__)
+                         string file = __FILE__, size_t line = __LINE__)
     if (isLikeAssociativeArray!(U, T))
 {
     import std.conv: to;
@@ -255,7 +255,7 @@ void shouldNotBeIn(T, U)(in auto ref T value, in auto ref U container,
  * Throws: UnitTestException on failure
  */
 void shouldNotBeIn(T, U)(in auto ref T value, U container,
-                         string file = __FILE__, in size_t line = __LINE__)
+                         string file = __FILE__, size_t line = __LINE__)
     if (!isLikeAssociativeArray!(U, T) && isInputRange!U)
 {
     import std.algorithm: find;
@@ -316,7 +316,7 @@ private struct ThrownInfo
  * throw the expected exception)
  */
 auto shouldThrow(T : Throwable = Exception, E)
-                (lazy E expr, string file = __FILE__, in size_t line = __LINE__)
+                (lazy E expr, string file = __FILE__, size_t line = __LINE__)
 {
     import std.conv: text;
 
@@ -389,7 +389,7 @@ auto shouldThrow(T : Throwable = Exception, E)
  * throw the expected exception)
  */
 auto shouldThrowExactly(T : Throwable = Exception, E)(lazy E expr,
-    string file = __FILE__, in size_t line = __LINE__)
+    string file = __FILE__, size_t line = __LINE__)
 {
     import std.conv: text;
 
@@ -411,7 +411,7 @@ auto shouldThrowExactly(T : Throwable = Exception, E)(lazy E expr,
  * Throws: UnitTestException on failure
  */
 void shouldNotThrow(T: Throwable = Exception, E)(lazy E expr,
-    string file = __FILE__, in size_t line = __LINE__)
+    string file = __FILE__, size_t line = __LINE__)
 {
     if (threw!T(expr).threw)
         fail("Expression threw", file, line);
@@ -693,7 +693,7 @@ bool isEqual(V, E)(scope V value, scope E expected)
  * Verify that rng is empty.
  * Throws: UnitTestException on failure.
  */
-void shouldBeEmpty(R)(in auto ref R rng, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeEmpty(R)(in auto ref R rng, string file = __FILE__, size_t line = __LINE__)
 if (isInputRange!R)
 {
     import std.conv: text;
@@ -705,7 +705,7 @@ if (isInputRange!R)
  * Verify that rng is empty.
  * Throws: UnitTestException on failure.
  */
-void shouldBeEmpty(R)(auto ref shared(R) rng, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeEmpty(R)(auto ref shared(R) rng, string file = __FILE__, size_t line = __LINE__)
 if (isInputRange!R)
 {
     import std.conv: text;
@@ -718,7 +718,7 @@ if (isInputRange!R)
  * Verify that aa is empty.
  * Throws: UnitTestException on failure.
  */
-void shouldBeEmpty(T)(auto ref T aa, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeEmpty(T)(auto ref T aa, string file = __FILE__, size_t line = __LINE__)
 if (isAssociativeArray!T)
 {
     //keys is @system
@@ -746,7 +746,7 @@ if (isAssociativeArray!T)
  * Verify that rng is not empty.
  * Throws: UnitTestException on failure.
  */
-void shouldNotBeEmpty(R)(R rng, string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeEmpty(R)(R rng, string file = __FILE__, size_t line = __LINE__)
 if (isInputRange!R)
 {
     if (rng.empty)
@@ -757,7 +757,7 @@ if (isInputRange!R)
  * Verify that aa is not empty.
  * Throws: UnitTestException on failure.
  */
-void shouldNotBeEmpty(T)(in auto ref T aa, string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeEmpty(T)(in auto ref T aa, string file = __FILE__, size_t line = __LINE__)
 if (isAssociativeArray!T)
 {
     //keys is @system
@@ -786,7 +786,7 @@ if (isAssociativeArray!T)
  * Throws: UnitTestException on failure.
  */
 void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
-                               string file = __FILE__, in size_t line = __LINE__)
+                               string file = __FILE__, size_t line = __LINE__)
 {
     import std.conv: text;
     if (t <= u)
@@ -805,7 +805,7 @@ void shouldBeGreaterThan(T, U)(in auto ref T t, in auto ref U u,
  * Throws: UnitTestException on failure.
  */
 void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
-                               string file = __FILE__, in size_t line = __LINE__)
+                               string file = __FILE__, size_t line = __LINE__)
 {
     import std.conv: text;
     if (t >= u)
@@ -824,7 +824,7 @@ void shouldBeSmallerThan(T, U)(in auto ref T t, in auto ref U u,
  * Verify that t and u represent the same set (ordering is not important).
  * Throws: UnitTestException on failure.
  */
-void shouldBeSameSetAs(V, E)(auto ref V value, auto ref E expected, string file = __FILE__, in size_t line = __LINE__)
+void shouldBeSameSetAs(V, E)(auto ref V value, auto ref E expected, string file = __FILE__, size_t line = __LINE__)
 if (isInputRange!V && isInputRange!E && is(typeof(value.front != expected.front) == bool))
 {
     import std.algorithm: sort;
@@ -888,7 +888,7 @@ private bool isSameSet(T, U)(auto ref T t, auto ref U u) {
  * Verify that value and expected do not represent the same set (ordering is not important).
  * Throws: UnitTestException on failure.
  */
-void shouldNotBeSameSetAs(V, E)(auto ref V value, auto ref E expected, string file = __FILE__, in size_t line = __LINE__)
+void shouldNotBeSameSetAs(V, E)(auto ref V value, auto ref E expected, string file = __FILE__, size_t line = __LINE__)
 if (isInputRange!V && isInputRange!E && is(typeof(value.front != expected.front) == bool))
 {
     if (isSameSet(value, expected))
@@ -923,7 +923,7 @@ if (isInputRange!V && isInputRange!E && is(typeof(value.front != expected.front)
 void shouldBeSameJsonAs(in string actual,
                         in string expected,
                         string file = __FILE__,
-                        in size_t line = __LINE__)
+                        size_t line = __LINE__)
     @trusted // not @safe pure due to parseJSON
 {
     import std.json: parseJSON, JSONException;
@@ -959,7 +959,7 @@ auto should(V)(scope auto ref V value){
 
         bool opEquals(U)(auto ref U other,
                          string file = __FILE__,
-                         in size_t line = __LINE__)
+                         size_t line = __LINE__)
         {
             shouldNotEqual(forward!value, other, file, line);
             return true;
@@ -967,13 +967,13 @@ auto should(V)(scope auto ref V value){
 
         void opBinary(string op, R)(R range,
                                     string file = __FILE__,
-                                    in size_t line = __LINE__) const if(op == "in") {
+                                    size_t line = __LINE__) const if(op == "in") {
             shouldNotBeIn(forward!value, range, file, line);
         }
 
         void opBinary(string op, R)(R expected,
                                     string file = __FILE__,
-                                    in size_t line = __LINE__) const
+                                    size_t line = __LINE__) const
             if(op == "~" && isInputRange!R)
         {
             import std.conv: text;
@@ -1013,7 +1013,7 @@ auto should(V)(scope auto ref V value){
 
         bool opEquals(U)(auto ref U other,
                          string file = __FILE__,
-                         in size_t line = __LINE__)
+                         size_t line = __LINE__)
         {
             shouldEqual(forward!value, other, file, line);
             return true;
@@ -1021,7 +1021,7 @@ auto should(V)(scope auto ref V value){
 
         void opBinary(string op, R)(R range,
                                     string file = __FILE__,
-                                    in size_t line = __LINE__) const
+                                    size_t line = __LINE__) const
             if(op == "in")
         {
             shouldBeIn(forward!value, range, file, line);
@@ -1029,7 +1029,7 @@ auto should(V)(scope auto ref V value){
 
         void opBinary(string op, R)(R range,
                                     string file = __FILE__,
-                                    in size_t line = __LINE__) const
+                                    size_t line = __LINE__) const
             if(op == "~" && isInputRange!R)
         {
             shouldBeSameSetAs(forward!value, range, file, line);
@@ -1073,7 +1073,7 @@ void shouldBeBetween(A, L, U)
      auto ref L lowerBound,
      auto ref U upperBound,
      string file = __FILE__,
-     in size_t line = __LINE__)
+     size_t line = __LINE__)
 {
     import std.conv: text;
     if(actual < lowerBound || actual >= upperBound)

--- a/subpackages/exception/source/unit_threaded/exception.d
+++ b/subpackages/exception/source/unit_threaded/exception.d
@@ -3,12 +3,12 @@
  */
 module unit_threaded.exception;
 
-void fail(const string output, const string file, in size_t line) @safe pure
+void fail(const string output, const string file, size_t line) @safe pure
 {
     throw new UnitTestException([output], file, line);
 }
 
-void fail(const string[] lines, const string file, in size_t line) @safe pure
+void fail(const string[] lines, const string file, size_t line) @safe pure
 {
     throw new UnitTestException(lines, file, line);
 }
@@ -19,13 +19,13 @@ void fail(const string[] lines, const string file, in size_t line) @safe pure
 class UnitTestException : Exception
 {
     this(const string msg, string file = __FILE__,
-         in size_t line = __LINE__, Throwable next = null) @safe pure nothrow
+         size_t line = __LINE__, Throwable next = null) @safe pure nothrow
     {
         this([msg], file, line, next);
     }
 
     this(const string[] msgLines, string file = __FILE__,
-         in size_t line = __LINE__, Throwable next = null) @safe pure nothrow
+         size_t line = __LINE__, Throwable next = null) @safe pure nothrow
     {
         import std.string: join;
         super(msgLines.join("\n"), next, file.dup, line);

--- a/subpackages/property/source/unit_threaded/property.d
+++ b/subpackages/property/source/unit_threaded/property.d
@@ -20,8 +20,8 @@ class PropertyException : Exception
  */
 void check(alias F, int numFuncCalls = 100)
           (in uint seed = from!"std.random".unpredictableSeed,
-           in string file = __FILE__,
-           in size_t line = __LINE__)
+           string file = __FILE__,
+           size_t line = __LINE__)
 {
     import unit_threaded.randomized.random: RndValueGen;
     import unit_threaded.exception: UnitTestException;


### PR DESCRIPTION
Split into two commits, as after using the switch, I realized some places used `in` for `file`, so I went ahead and unified it.