### PR TITLE
Make unit-threaded unit tests pass on Windows.

### DIFF
--- a/tests/unit_threaded/ut/io.d
+++ b/tests/unit_threaded/ut/io.d
@@ -408,6 +408,7 @@ unittest {
     import unit_threaded.runner.testcase: TestCase;
     import unit_threaded.should;
     import std.string: splitLines;
+    import std.path: buildPath;
 
     enableDebugOutput(false);
 
@@ -450,7 +451,7 @@ unittest {
     oops();
     writer.output.splitLines.should == [
         "OopsTest:",
-        "    tests/unit_threaded/ut/io.d:432 - oops",
+        "    " ~ buildPath("tests", "unit_threaded", "ut", "io.d") ~ ":433 - oops",
         "",
     ];
 }

--- a/tests/unit_threaded/ut/randomized/gen.d
+++ b/tests/unit_threaded/ut/randomized/gen.d
@@ -2,6 +2,12 @@ module unit_threaded.ut.randomized.gen;
 
 import unit_threaded.randomized.gen;
 
+/*
+Regarding `version(OldWindows)` blocks below: It is unclear what conditions
+made Windows behave differently. Nowadays, with dmd v2.094 on Windows 10 in
+November 2020, there is no difference between Windows and Posix.
+*/
+
 @safe pure unittest {
     import unit_threaded.asserts: assertEqual;
     import std.random: Random;
@@ -79,7 +85,7 @@ else {
         GenASCIIString!() gen;
         assertEqual(gen.gen(rnd), "");
         assertEqual(gen.gen(rnd), "a");
-        version(Windows)
+        version(OldWindows) // See comment above.
             assertEqual(gen.gen(rnd), "yt4>%PnZwJ*Nv3L5:9I#N_ZK");
         else
             assertEqual(gen.gen(rnd), "i<pDqp7-LV;W`d)w/}VXi}TR=8CO|m");
@@ -96,7 +102,7 @@ else {
 
     // first the front-loaded values
     assertEqual(gen.gen(rnd), []);
-    version(Windows)
+    version(OldWindows) // See comment above.
         assertEqual(gen.gen(rnd), [0, 1]);
     else
         assertEqual(gen.gen(rnd), [0, 1, -2147483648, 2147483647, 681542492, 913057000, 1194544295, -1962453543, 1972751015]);
@@ -124,7 +130,7 @@ else {
     // first the front-loaded values
     assertEqual(gen.gen(rnd), []);
     // then the pseudo-random ones
-    version(Windows)
+    version(OldWindows) // See comment above.
         assertEqual(gen.gen(rnd).length, 2);
     else
         assertEqual(gen.gen(rnd).length, 9);


### PR DESCRIPTION
Hi Átila,

In anticipation of my next PR, these changes make the unit tests pass for me. If you have any idea why previously a `version(Windows)` was necessary and now it isn't, please let me know.

Thanks,
Bastiaan.