### PR TITLE
Handle ProcessException.

### DIFF
--- a/subpackages/integration/source/unit_threaded/integration.d
+++ b/subpackages/integration/source/unit_threaded/integration.d
@@ -182,13 +182,19 @@ struct Sandbox {
         @safe const
     {
         import unit_threaded.exception: UnitTestException;
+        import std.process: ProcessException;
         import std.conv: text;
         import std.array: join;
 
-        const res = executeInSandbox(args);
-        if(res.status != 0)
-           throw new UnitTestException(text("Could not execute `", args.join(" "), "`:\n", res.output),
-                                       file, line);
+        try {
+            const res = executeInSandbox(args);
+            if(res.status != 0)
+               throw new UnitTestException(text("Could not execute `", args.join(" "), "`:\n", res.output),
+                                           file, line);
+        } catch (ProcessException e) {
+            throw new UnitTestException(text("Could not execute `", args.join(" "), "`:\n", e.msg),
+                                        file, line);
+        }
     }
 
     alias shouldExecuteOk = shouldSucceed;
@@ -201,15 +207,18 @@ struct Sandbox {
         @safe const
     {
         import unit_threaded.exception: UnitTestException;
+        import std.process: ProcessException;
         import std.conv: text;
         import std.array: join;
 
-        const res = executeInSandbox(args);
-        if(res.status == 0)
-            throw new UnitTestException(
-                text("`", args.join(" "), "` should have failed but didn't:\n", res.output),
-                file,
-                line);
+        try {
+            const res = executeInSandbox(args);
+            if(res.status == 0)
+                throw new UnitTestException(
+                    text("`", args.join(" "), "` should have failed but didn't:\n", res.output),
+                    file,
+                    line);
+        } catch (ProcessException) {} // Allow failure by ProcessException.
     }
 
 

--- a/tests/unit_threaded/ut/integration.d
+++ b/tests/unit_threaded/ut/integration.d
@@ -91,3 +91,21 @@ version(Windows) {
         }
     }
 }
+
+@safe unittest {
+    with(immutable Sandbox()) {
+        import unit_threaded.should;
+
+        shouldSucceed("definitely_not_an_existing_command_or_executable").shouldThrow;
+        shouldFail("definitely_not_an_existing_command_or_executable");
+
+        writeFile("hello.d", q{import std; void main() {writeln("hello");}});
+        shouldExecuteOk(["dmd", inSandboxPath("hello.d")]);
+        version (Windows)
+            immutable exe = "hello.exe";
+        else
+            immutable exe = "hello";
+        shouldSucceed(inSandboxPath(exe));
+        shouldFail(inSandboxPath(exe)).shouldThrow;
+    }
+}

--- a/tests/unit_threaded/ut/io.d
+++ b/tests/unit_threaded/ut/io.d
@@ -408,6 +408,7 @@ unittest {
     import unit_threaded.runner.testcase: TestCase;
     import unit_threaded.should;
     import std.string: splitLines;
+    import std.path: buildPath;
 
     enableDebugOutput(false);
 
@@ -450,7 +451,7 @@ unittest {
     oops();
     writer.output.splitLines.should == [
         "OopsTest:",
-        "    tests/unit_threaded/ut/io.d:432 - oops",
+        "    " ~ buildPath("tests", "unit_threaded", "ut", "io.d") ~ ":433 - oops",
         "",
     ];
 }

--- a/tests/unit_threaded/ut/randomized/gen.d
+++ b/tests/unit_threaded/ut/randomized/gen.d
@@ -2,6 +2,12 @@ module unit_threaded.ut.randomized.gen;
 
 import unit_threaded.randomized.gen;
 
+/*
+Regarding `version(OldWindows)` blocks below: It is unclear what conditions
+made Windows behave differently. Nowadays, with dmd v2.094 on Windows 10 in
+November 2020, there is no difference between Windows and Posix.
+*/
+
 @safe pure unittest {
     import unit_threaded.asserts: assertEqual;
     import std.random: Random;
@@ -79,7 +85,7 @@ else {
         GenASCIIString!() gen;
         assertEqual(gen.gen(rnd), "");
         assertEqual(gen.gen(rnd), "a");
-        version(Windows)
+        version(OldWindows) // See comment above.
             assertEqual(gen.gen(rnd), "yt4>%PnZwJ*Nv3L5:9I#N_ZK");
         else
             assertEqual(gen.gen(rnd), "i<pDqp7-LV;W`d)w/}VXi}TR=8CO|m");
@@ -96,7 +102,7 @@ else {
 
     // first the front-loaded values
     assertEqual(gen.gen(rnd), []);
-    version(Windows)
+    version(OldWindows) // See comment above.
         assertEqual(gen.gen(rnd), [0, 1]);
     else
         assertEqual(gen.gen(rnd), [0, 1, -2147483648, 2147483647, 681542492, 913057000, 1194544295, -1962453543, 1972751015]);
@@ -124,7 +130,7 @@ else {
     // first the front-loaded values
     assertEqual(gen.gen(rnd), []);
     // then the pseudo-random ones
-    version(Windows)
+    version(OldWindows) // See comment above.
         assertEqual(gen.gen(rnd).length, 2);
     else
         assertEqual(gen.gen(rnd).length, 9);


### PR DESCRIPTION
`std.process.execute` will throw `ProcessException` if, for example, the command cannot be found.  This PR fixes `shouldSucceed` and `shoudlFail` to handle this exception.

You may want to pull #230 first.