### PR TITLE
Windows: Try re-enabling escape codes for output console before printing summary

### DIFF
--- a/subpackages/runner/source/unit_threaded/runner/testsuite.d
+++ b/subpackages/runner/source/unit_threaded/runner/testsuite.d
@@ -168,6 +168,13 @@ private:
             }
         }
 
+        version(Windows) {
+            // spawned child processes etc. may have tampered with the console,
+            // try to re-enable the ANSI escape codes for colors
+            import unit_threaded.runner.io: tryEnableEscapeCodes;
+            tryEnableEscapeCodes();
+        }
+
         handleFailures();
 
         _stopWatch.stop();


### PR DESCRIPTION
E.g., they were disabled by the time the summary was printed for the reggae integration tests - the unittests worked fine.