### PR TITLE
Add UnitTestError as alternative to UnitTestException.

### DIFF
--- a/subpackages/exception/source/unit_threaded/exception.d
+++ b/subpackages/exception/source/unit_threaded/exception.d
@@ -16,7 +16,17 @@ void fail(const string[] lines, const string file, size_t line) @safe pure
 /**
  * An exception to signal that a test case has failed.
  */
-class UnitTestException : Exception
+public class UnitTestException : Exception
+{
+    mixin UnitTestFailureImpl;
+}
+
+public class UnitTestError : Error
+{
+    mixin UnitTestFailureImpl;
+}
+
+private template UnitTestFailureImpl()
 {
     this(const string msg, string file = __FILE__,
          size_t line = __LINE__, Throwable next = null) @safe pure nothrow
@@ -28,7 +38,14 @@ class UnitTestException : Exception
          size_t line = __LINE__, Throwable next = null) @safe pure nothrow
     {
         import std.string: join;
-        super(msgLines.join("\n"), next, file.dup, line);
+        static if (is(typeof(this) : Exception))
+        {
+            super(msgLines.join("\n"), next, file.dup, line);
+        }
+        else
+        {
+            super(msgLines.join("\n"), file.dup, line, next);
+        }
         this.msgLines = msgLines.dup;
     }
 

--- a/subpackages/runner/source/unit_threaded/runner/testcase.d
+++ b/subpackages/runner/source/unit_threaded/runner/testcase.d
@@ -108,11 +108,13 @@ private:
     }
 
     final bool check(E)(lazy E expression) {
-        import unit_threaded.exception: UnitTestException;
+        import unit_threaded.exception: UnitTestError, UnitTestException;
         try {
             expression();
         } catch(UnitTestException ex) {
             fail(ex.toString());
+        } catch(UnitTestError err) {
+            fail(err.toString());
         } catch(Throwable ex) {
             fail("\n    " ~ ex.toString() ~ "\n");
         }


### PR DESCRIPTION
The aim is a type with these two properties:
- when caught, it is logged with just a line, no backtrace
- but it is never caught by the application, even if it does `catch(Exception)`.

I've had problems where aggressive exception handlers in the application ate a `UnitTestException`. However, if I make `UnitTestException` into `UnitTestError` in unit-threaded, it is no longer @safe to catch, and that breaks ~everything. So this PR is a minimal backdoor way to let `dshould` subclass `UnitTestError` so that it can throw errors instead, which won't be caught by the application ever, but still be logged compactly in the `unit-threaded` runner.