### PR TITLE
Implement BDD/Gherkin style output.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -21,7 +21,8 @@
         ":runner": "*",
         ":mocks": "*",
         ":integration": "*",
-        ":property": "*"
+        ":property": "*",
+        ":behave": "*"
     },
     "subPackages": [
         "./subpackages/from",
@@ -31,7 +32,8 @@
         "./subpackages/mocks",
         "./subpackages/integration",
         "./subpackages/property",
-        "./subpackages/autorunner"
+        "./subpackages/autorunner",
+        "./subpackages/behave"
     ],
     "configurations": [
 

--- a/subpackages/behave/dub.sdl
+++ b/subpackages/behave/dub.sdl
@@ -1,0 +1,6 @@
+name "behave"
+description "BDD output formatting"
+authors "Atila Neves"
+license "BSD 3-clause"
+targetType "library"
+dependency "unit-threaded:runner" path="../.."

--- a/subpackages/behave/source/unit_threaded/behave.d
+++ b/subpackages/behave/source/unit_threaded/behave.d
@@ -1,0 +1,157 @@
+module unit_threaded.behave;
+
+import std.algorithm;
+import std.array;
+import std.format;
+import std.path: baseName;
+import std.range;
+import std.string;
+import unit_threaded.runner.io;
+import unit_threaded.runner.testcase;
+
+public:
+
+alias background = printBehaveLine!"Background:";
+alias given = printBehaveLine!"Given";
+alias when = printBehaveLine!"When";
+alias then = printBehaveLine!"Then";
+
+private:
+
+template printBehaveLine(string mode) {
+    public void printBehaveLine(string file = __FILE__, size_t line = __LINE__, T...)(string message, T args) {
+        // to save space, only use the filename.
+        const stepLocation = format!"# %s:%s"(file.baseName, line);
+        output.setBehaveLine(mode, format(message, args).intenseQuotes, stepLocation);
+    }
+    public void printBehaveLine(string fmt, string file = __FILE__, size_t line = __LINE__, T...)(T args) {
+        // to save space, only use the filename.
+        const stepLocation = format!"# %s:%s"(file.baseName, line);
+        output.setBehaveLine(mode, format!fmt(args).intenseQuotes, stepLocation);
+    }
+}
+
+string intenseQuotes(string text) {
+    if (!_useEscCodes)
+        // preserve `` in that case
+        return text;
+    // [a] => [a]
+    // [a, b] => [a, b.intense]
+    alias markIntense = pair => chain(pair.take(1), pair.drop(1).map!intense);
+    return text.splitter('`').chunks(2).map!markIntense.joiner.join;
+}
+
+@("mark quotes with intense formatting")
+unittest
+{
+    auto result = "Given `Hello` and `World`".intenseQuotes;
+
+    if (_useEscCodes) {
+        assert(result == "Given \033[1mHello\033[0m and \033[1mWorld\033[0m");
+    } else {
+        assert(result == "Given `Hello` and `World`");
+    }
+}
+
+private size_t visibleLength(string ansiFormattedText) @safe {
+    return ansiFormattedText
+        .splitter("\033[")
+        .mapExceptFirst!(fragment => fragment.find("m").drop(1))
+        .map!"a.length"
+        .sum;
+}
+
+@("visible length of string")
+unittest {
+    assert(("Hello " ~ green("World")).visibleLength == "Hello World".length);
+}
+
+private alias mapExceptFirst(alias pred) = range => chain(range.take(1), range.drop(1).map!pred);
+
+class BehaveOutput: Output {
+    this(Output next) {
+        _next = next;
+    }
+
+    override void send(in string output) @safe {
+        removePartial;
+        _next.send(output);
+    }
+
+    override void flush(bool success) @safe {
+        finishBehaveLine(success);
+        // for spacing
+        _next.send("\n");
+        _next.flush(success);
+    }
+
+package:
+
+    void setBehaveLine(Output, Location)(string mode, Output output, Location location) @safe
+    {
+        // for spacing
+        if (_previousMode == "")
+            _next.send("\n");
+        finishBehaveLine(true);
+        if (mode == _previousMode)
+            mode = "And";
+        else _previousMode = mode;
+        _behaveLine = "\t" ~ mode.intense ~ " " ~ output;
+        _longestLine = max(_longestLine, _behaveLine.visibleLength);
+        _location = location;
+        _next.send(fullLine!noColor);
+        _partialLine = true;
+    }
+
+private:
+
+    void finishBehaveLine(bool success) @safe {
+        removePartial;
+        if (_behaveLine) {
+            _next.send((success ? fullLine!green : fullLine!red) ~ "\n");
+            _behaveLine = null;
+        }
+    }
+
+    void removePartial() @safe {
+        if (_partialLine) {
+            // delete current line, carriage return.
+            _next.send("\033[2K\r");
+            _partialLine = false;
+        }
+    }
+
+    final string fullLine(alias color)() @safe {
+        const spacing = ((_longestLine + 7) / 8) * 8 + 3 - _behaveLine.visibleLength;
+        return color(_behaveLine) ~ " ".repeat(spacing).join ~ _location;
+    }
+
+    // So we know to write 'Given...' 'And...'
+    string _previousMode;
+    // So we can flush on error, success or manual write.
+    bool _partialLine;
+    // Longest previous behave line output part.
+    // Used for stable indenting of location.
+    size_t _longestLine;
+    string _behaveLine;
+    string _location;
+    Output _next;
+}
+
+private alias noColor = s => s;
+
+// Return the current testcase's behave output.
+// If the current output is not a behave output, make it one.
+// TODO if there's another output wrapper like this, they'll
+// compete for being the "outermost". Instead, provide a way to
+// search the `next_` list.
+BehaveOutput output() {
+    import unit_threaded.runner.testcase: TestCase;
+
+    auto writer = TestCase.currentTest.getWriter;
+    if (auto behave = cast(BehaveOutput) writer)
+        return behave;
+    auto behave = new BehaveOutput(writer);
+    TestCase.currentTest._output = behave;
+    return behave;
+}

--- a/subpackages/runner/source/unit_threaded/runner/testcase.d
+++ b/subpackages/runner/source/unit_threaded/runner/testcase.d
@@ -58,7 +58,7 @@ class TestCase {
     bool shouldFail() @safe @nogc pure nothrow { return false; }
 
 
-package:
+package(unit_threaded):
 
     static TestCase currentTest;
     Output _output;
@@ -141,7 +141,7 @@ private:
     }
 
     final void flushOutput() {
-        getWriter.flush;
+        getWriter.flush(!_failed);
     }
 }
 

--- a/tests/unit_threaded/ut/behave.d
+++ b/tests/unit_threaded/ut/behave.d
@@ -1,0 +1,81 @@
+module unit_threaded.ut.behave;
+
+import unit_threaded.behave;
+import unit_threaded.runner.io;
+
+unittest {
+    import std.algorithm: map;
+    import std.exception: enforce;
+    import std.string: splitLines;
+    import unit_threaded.runner.testcase: TestCase;
+    import unit_threaded.should;
+
+    class TestOutput: Output {
+        string output;
+        override void send(in string output) {
+            this.output ~= output;
+        }
+        override void flush(bool failed) {}
+    }
+
+    class BehaveTest: TestCase {
+        override void test() {
+            given("the given step");
+            when("the when step");
+            then("the then step");
+            enforce!UnitTestError(false);
+        }
+        override string getPath() @safe pure nothrow const {
+            return "BehaveTest";
+        }
+    }
+
+    auto test = new BehaveTest;
+    auto writer = new TestOutput;
+    test.setOutput(writer);
+
+    test();
+    if (_useEscCodes) {
+        writer.output.splitLines.map!escapeAnsi.shouldEqual([
+            "BehaveTest:",
+            "",
+            "(tab)(intense)Given(normal) the given step      # behave.d:23(clearLine)",
+            "(green)(tab)(intense)Given(normal) the given step(default)      # behave.d:23",
+            "(tab)(intense)When(normal) the when step        # behave.d:24(clearLine)",
+            "(green)(tab)(intense)When(normal) the when step(default)        # behave.d:24",
+            "(tab)(intense)Then(normal) the then step        # behave.d:25(clearLine)",
+            "    tests/unit_threaded/ut/behave.d:26 - Enforcement failed",
+            "",
+            "(red)(tab)(intense)Then(normal) the then step(default)        # behave.d:25",
+            "",
+        ]);
+    } else {
+        writer.output.splitLines.map!escapeAnsi.shouldEqual([
+            "BehaveTest:",
+            "",
+            "(tab)Given the given step      # behave.d:23(clearLine)",
+            "(tab)Given the given step      # behave.d:23",
+            "(tab)When the when step        # behave.d:24(clearLine)",
+            "(tab)When the when step        # behave.d:24",
+            "(tab)Then the then step        # behave.d:25(clearLine)",
+            "    tests/unit_threaded/ut/behave.d:26 - Enforcement failed",
+            "",
+            "(tab)Then the then step        # behave.d:25",
+            "",
+        ]);
+    }
+}
+
+private string escapeAnsi(string line) {
+    import std.string: replace;
+
+    return line
+        .replace("\033[1m", "(intense)")
+        .replace("\033[31m", "(red)")
+        .replace("\033[32m", "(green)")
+        .replace("\033[39m", "(default)")
+        .replace("\033[22m", "(normal)")
+        .replace("\033[2K", "(clearLine)")
+        .replace("\t", "(tab)")
+        .replace("\033", "\\033");
+}

--- a/tests/unit_threaded/ut/io.d
+++ b/tests/unit_threaded/ut/io.d
@@ -16,7 +16,7 @@ unittest {
             this.output ~= output;
         }
 
-        override void flush() {}
+        override void flush(bool failed) {}
     }
 
     class PrintTest: TestCase {
@@ -59,7 +59,7 @@ unittest {
             this.output ~= output;
         }
 
-        override void flush() {}
+        override void flush(bool failed) {}
     }
 
     class PrintTest: TestCase {
@@ -419,7 +419,7 @@ unittest {
             this.output ~= output;
         }
 
-        override void flush() {}
+        override void flush(bool failed) {}
     }
 
     class OkTest: TestCase {


### PR DESCRIPTION
Annotate your tests with given/when/then steps.
Failing steps will be shown in red; successful steps in green.

The goal of this PR is to imitate the output of Python's [behave](https://behave.readthedocs.io/en/stable/) or Node's [cucumber.js](https://www.testim.io/blog/cucumber-js-for-bdd-an-introductory-tutorial-with-examples/).

However, instead of defining a library of steps that a feature file is parsed from, it merely adds a set of functions that generate given/when/then lines in the output.

This is (relatively) isolated to its own module `behave.d`, which defines a stateful output class that keeps track of what the last step was, and erases it (with ANSI codes) if non-behave output is required.

There is also a hefty refactoring of ANSI formatting that replaces the string-based codes with a token stream. The reason for this is that it is otherwise awkward to "turn (intense) formatting back off", because you need to know which format codes are "on" at that point.

Example from some internal code I used to try it:

```
import unit_threaded.behave;
...
unittest {
    ...
    then("an `expected track change` is published");
    int i; assert(i > 0);
```

![Screenshot_20220809_161517](https://user-images.githubusercontent.com/540727/183672144-0d2438f8-2d43-421b-9668-6d5d41d1337d.png)
