### PR TITLE
Without ANSI escape codes, don't erase previous line.

### DIFF
--- a/subpackages/behave/source/unit_threaded/behave.d
+++ b/subpackages/behave/source/unit_threaded/behave.d
@@ -99,8 +99,11 @@ package:
         _behaveLine = "\t" ~ mode.intense ~ " " ~ output;
         _longestLine = max(_longestLine, _behaveLine.visibleLength);
         _location = location;
-        _next.send(fullLine!noColor);
-        _partialLine = true;
+        if (_useEscCodes) {
+            // otherwise, we won't be able to erase it later
+            _next.send(fullLine!noColor);
+            _partialLine = true;
+        }
     }
 
 private:
@@ -115,6 +118,7 @@ private:
 
     void removePartial() @safe {
         if (_partialLine) {
+            assert(_useEscCodes);
             // delete current line, carriage return.
             _next.send("\033[2K\r");
             _partialLine = false;

--- a/tests/unit_threaded/ut/behave.d
+++ b/tests/unit_threaded/ut/behave.d
@@ -53,11 +53,8 @@ unittest {
         writer.output.splitLines.map!escapeAnsi.shouldEqual([
             "BehaveTest:",
             "",
-            "(tab)Given the given step      # behave.d:23(clearLine)",
             "(tab)Given the given step      # behave.d:23",
-            "(tab)When the when step        # behave.d:24(clearLine)",
             "(tab)When the when step        # behave.d:24",
-            "(tab)Then the then step        # behave.d:25(clearLine)",
             "    tests/unit_threaded/ut/behave.d:26 - Enforcement failed",
             "",
             "(tab)Then the then step        # behave.d:25",


### PR DESCRIPTION
If ANSI escape codes are disabled, don't try to use the "erase previous line" code for coloring behave output.

I only noticed this when looking at the behave output in our CI. (Which actually understands color, but not `\033[2K`.)