### PR TITLE
light.fail: Remove 'in' on escaped string parameter

### DIFF
--- a/source/unit_threaded/light.d
+++ b/source/unit_threaded/light.d
@@ -484,7 +484,7 @@ private void assert_(bool value, string message, string file, size_t line) @safe
         throw new Exception(message, file, line);
 }
 
-void fail(in string output, string file, size_t line) @safe pure {
+void fail(string output, string file, size_t line) @safe pure {
     assert_(false, output, file, line);
 }
 


### PR DESCRIPTION
output is passed as the 'message' argument to 'assert_', which can be assigned to an Exception's field,
which obviously escape this function's context.