### PR TITLE
Disable UDA search on overloads entirely pending `getOverloads` actually working

### DIFF
--- a/subpackages/runner/source/unit_threaded/runner/reflection.d
+++ b/subpackages/runner/source/unit_threaded/runner/reflection.d
@@ -179,12 +179,9 @@ private TestData[] moduleUnitTests_(alias module_)() {
         void function()[] ret;
         foreach(memberStr; __traits(allMembers, composite)) {
             static if(__traits(compiles, Identity!(__traits(getMember, composite, memberStr)))) {
-                static if (__traits(getOverloads, composite, memberStr).length > 0) {
-                    alias members = AliasSeq!(__traits(getOverloads, composite, memberStr));
-                } else {
-                    alias members = AliasSeq!(__traits(getMember, composite, memberStr));
-                }
-                static foreach (member; members) {
+                // Disable UDA search on overloads entirely pending https://issues.dlang.org/show_bug.cgi?id=23855
+                static if (__traits(getOverloads, composite, memberStr).length <= 1) {
+                    alias member = __traits(getMember, composite, memberStr);
                     static if(__traits(compiles, &member)) {
                         static if(isSomeFunction!member && hasUDA!(member, uda)) {
                             ret ~= &member;


### PR DESCRIPTION
See https://issues.dlang.org/show_bug.cgi?id=23855 : When trying to run `unit-threaded` in a project containing code like

```
void test()() { }
void test(int) { }
```

The `__traits(getAttributes)` deprecation kicks in because `__traits(getOverloads)` fails to correctly disambiguate the symbols.

As I was unable to fix it in DMD *or* find a workaround, let's just turn off UDA search on overloaded symbols. How often is a unittest function going to be overloaded?

edit: A less radical solution would be to turn it off for overloads containing templates. Honestly I think that's more accomodation than DMD's broken behavior deserves though.