### PR TITLE
Adapt to druntime v2.102 and Throwables owning their `.info` TraceInfo

### DIFF
--- a/subpackages/runner/source/unit_threaded/runner/testcase.d
+++ b/subpackages/runner/source/unit_threaded/runner/testcase.d
@@ -326,14 +326,14 @@ class BuiltinTestCase: FunctionTestCase {
             else
             {
                 // grab a stack trace inside this function
-                Throwable.TraceInfo localTraceInfo;
+                Exception localException;
                 try
                     throw new Exception("");
                 catch (Exception exc)
-                    localTraceInfo = exc.info;
+                    localException = exc;
 
                 // 3 = BuiltinTestCase + FunctionTestCase + runner reflection
-                fail(e, localTraceInfo, 3);
+                fail(e, localException.info, 3);
             }
         }
     }


### PR DESCRIPTION
A GC'd Throwable frees the newly malloc'd TraceInfo instance, so using a TraceInfo ref without keeping a reference to the owning Throwable is dangerous.