### PR TITLE
Add `-j N` option to customize the number of test threads

### DIFF
--- a/source/unit_threaded/static_.d
+++ b/source/unit_threaded/static_.d
@@ -40,7 +40,7 @@ version(unitThreadedLight) {
             if(singleThreaded)
                 foreach(module_; modules)
                     runModuleTests(module_);
-             else
+            else
                 foreach(module_; modules.parallel)
                     runModuleTests(module_);
 

--- a/subpackages/runner/source/unit_threaded/runner/options.d
+++ b/subpackages/runner/source/unit_threaded/runner/options.d
@@ -6,7 +6,7 @@ module unit_threaded.runner.options;
 
 ///
 struct Options {
-    bool multiThreaded;
+    uint numThreads;
     string[] testsToRun;
     bool debugOutput;
     bool list;
@@ -29,6 +29,7 @@ auto getOptions(string[] args) {
     import std.getopt: getopt, defaultGetoptPrinter;
 
     bool single;
+    uint numThreads;
     bool debugOutput;
     bool help;
     bool list;
@@ -42,6 +43,7 @@ auto getOptions(string[] args) {
     auto helpInfo =
         getopt(args,
                "single|s", "Run in one thread", &single,
+               "jobs|j", "Number of parallel test threads. Defaults to the number of logical CPU cores.", &numThreads,
                "debug|d", "Print debug output", &debugOutput,
                "esccodes|e", "force ANSI escape codes even for !isatty", &forceEscCodes,
                "list|l", "List available tests", &list,
@@ -65,7 +67,10 @@ auto getOptions(string[] args) {
     version(unitUnthreaded)
         single = true;
 
+    if (single)
+        numThreads = 1; // let -s override -j
+
     immutable exit =  help || list;
-    return Options(!single, args[1..$], debugOutput, list, exit, forceEscCodes,
+    return Options(numThreads, args[1..$], debugOutput, list, exit, forceEscCodes,
                    random, seed, stackTraces, showChrono, quiet);
 }

--- a/subpackages/runner/source/unit_threaded/runner/testsuite.d
+++ b/subpackages/runner/source/unit_threaded/runner/testsuite.d
@@ -166,9 +166,12 @@ private:
 
         _stopWatch.start();
 
-        if (_options.multiThreaded) {
+        const numThreads = _options.numThreads;
+        if (numThreads != 1) {
             // use a dedicated task pool with non-daemon worker threads
-            auto taskPool = new TaskPool;
+            auto taskPool = numThreads == 0
+                ? new TaskPool()                // use all logical CPU cores
+                : new TaskPool(numThreads - 1); // main thread is used too
             _failures = reduce!((a, b) => a ~ b)(_failures, taskPool.amap!runTest(tests));
             taskPool.finish(/*blocking=*/false);
         } else {


### PR DESCRIPTION
E.g., there are scenarios where using lots of threads actually signficantly increases the overall runtime.