### PR TITLE
use noreturn

### DIFF
--- a/source/unit_threaded/light.d
+++ b/source/unit_threaded/light.d
@@ -499,8 +499,9 @@ private void assert_(bool value, string message, string file, size_t line) @safe
         throw new Exception(message, file, line);
 }
 
-void fail(string output, string file, size_t line) @safe pure {
+noreturn fail(string output, string file, size_t line) @safe pure {
     assert_(false, output, file, line);
+    assert(0);
 }
 
 

--- a/subpackages/exception/source/unit_threaded/exception.d
+++ b/subpackages/exception/source/unit_threaded/exception.d
@@ -19,22 +19,22 @@ module unit_threaded.exception;
 import std.sumtype;
 import std.typecons;
 
-void fail(const string output, const string file, size_t line) @safe pure
+noreturn fail(const string output, const string file, size_t line) @safe pure
 {
     throw new UnitTestException([output], file, line);
 }
 
-void fail(const string[] lines, const string file, size_t line) @safe pure
+noreturn fail(const string[] lines, const string file, size_t line) @safe pure
 {
     throw new UnitTestException(lines, file, line);
 }
 
-package void fail(Throwable throwable) @safe pure
+package noreturn fail(Throwable throwable) @safe pure
 {
     throw new UnitTestException(throwable);
 }
 
-package void fail(Throwable throwable, Throwable.TraceInfo traceInfo, int removeExtraLines) @safe pure
+package noreturn fail(Throwable throwable, Throwable.TraceInfo traceInfo, int removeExtraLines) @safe pure
 {
     throw new UnitTestException(throwable, traceInfo, removeExtraLines);
 }


### PR DESCRIPTION
so users don't need to put `assert(0);` after their calls to `fail`.