### PR TITLE
Fix -j behavior

### DIFF
--- a/subpackages/runner/source/unit_threaded/runner/options.d
+++ b/subpackages/runner/source/unit_threaded/runner/options.d
@@ -57,7 +57,7 @@ struct Options {
             numThreads = 1; // let -s override -j
 
         if (numThreads == 0)
-            numThreads = totalCPUs - 1;
+            numThreads = totalCPUs;
 
         exit =  help || list;
     }

--- a/subpackages/runner/source/unit_threaded/runner/testsuite.d
+++ b/subpackages/runner/source/unit_threaded/runner/testsuite.d
@@ -166,9 +166,9 @@ private:
 
         _stopWatch.start();
 
-        if (_options.numThreads != 1) {
+        if (_options.numThreads > 1) {
             // use a dedicated task pool with non-daemon worker threads
-            auto taskPool = new TaskPool(_options.numThreads);
+            auto taskPool = new TaskPool(_options.numThreads - 1); // main thread is used too
             _failures = reduce!((a, b) => a ~ b)(_failures, taskPool.amap!runTest(tests));
             taskPool.finish(/*blocking=*/false);
         } else {


### PR DESCRIPTION
This was broken after my PR - `-j2` would lead to 2 additional worker threads, yielding 3 threads in total.

And it would default to single-thread mode on a dual-core machine.