### PR TITLE
Fix random runner seed initialization

### DIFF
--- a/subpackages/runner/source/unit_threaded/runner/options.d
+++ b/subpackages/runner/source/unit_threaded/runner/options.d
@@ -25,6 +25,7 @@ struct Options {
 
         bool single;
         bool help;
+        immutable seedSet = args.hasSeedArg;
 
         auto helpInfo =
             getopt(args,
@@ -50,6 +51,8 @@ struct Options {
         if(random) {
             if(!single) writeln("-r implies -s, running in a single thread\n");
             single = true;
+            if(!seedSet)
+                seed = randomSeed;
         }
 
         version(unitUnthreaded)
@@ -63,4 +66,25 @@ struct Options {
 
         exit =  help || list;
     }
+}
+
+private bool hasSeedArg(scope const string[] args) @safe pure {
+    import std.algorithm: startsWith;
+
+    foreach(arg; args)
+        if(arg == "--seed" || arg.startsWith("--seed="))
+            return true;
+
+    return false;
+}
+
+private uint randomSeed() @safe {
+    import std.random: unpredictableSeed;
+
+    uint seed;
+    do
+        seed = unpredictableSeed;
+    while(seed == 0);
+
+    return seed;
 }

--- a/tests/unit_threaded/ut/runner_options.d
+++ b/tests/unit_threaded/ut/runner_options.d
@@ -32,3 +32,21 @@ unittest {
     assert(options.numThreads == 1);
     assert(options.random);
 }
+
+@("-r sets a random seed")
+unittest {
+    const options = Options(["ut", "-r"]);
+    assert(options.seed != 0);
+}
+
+@("-r respects an explicit seed")
+unittest {
+    const options = Options(["ut", "-r", "--seed", "123"]);
+    assert(options.seed == 123);
+}
+
+@("-r respects an explicit zero seed")
+unittest {
+    const options = Options(["ut", "-r", "--seed", "0"]);
+    assert(options.seed == 0);
+}


### PR DESCRIPTION
## Summary
- initialize a non-zero unpredictable seed when --random is used without --seed
- preserve explicitly provided seeds, including --seed 0
- add runner option regression tests

## Tests
- dub test --config=unittest