### PR TITLE
Avoid deprecated two-argument move in assertions

### DIFF
--- a/subpackages/assertions/source/unit_threaded/assertions.d
+++ b/subpackages/assertions/source/unit_threaded/assertions.d
@@ -1011,7 +1011,7 @@ auto should(V)(return scope auto ref V value) {
 
         this(ref Wrapper wrapper) {
             import std.algorithm.mutation : move;
-            move(wrapper, _wrapper);
+            _wrapper = move(wrapper);
         }
 
         bool opEquals(U)(auto ref U other,


### PR DESCRIPTION
The `ShouldNot` assertion wrapper uses the two-argument `std.algorithm.mutation.move` overload. DMD now deprecates that overload when the target `Wrapper` is not copyable.

Use the same return-value move form already used by `Should`: `_wrapper = move(wrapper)`. This preserves support for non-copyable wrapped values and removes the deprecation warning.

Verified with `build/ci.sh` using DMD.