### PR TITLE
Fix: Improve cross-platform compatibility for paths

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
     "license": "BSD 3-clause",
     "targetType": "library",
     "toolchainRequirements": {
-        "frontend": ">=2.089",
+        "frontend": ">=2.089"
     },
     "-ddoxFilterArgs": [
         "--unittest-examples",

--- a/gen/source/unit_threaded/runtime/runtime.d
+++ b/gen/source/unit_threaded/runtime/runtime.d
@@ -155,7 +155,9 @@ auto toDirEntry(string a) {
 string removePackage(string name) {
     import std.algorithm: endsWith;
     import std.array: replace;
-    enum toRemove = "/package.d";
+    import std.path : dirSeparator;
+    
+    enum toRemove = dirSeparator~"package.d";
     return name.endsWith(toRemove)
         ? name.replace(toRemove, "")
         : name;

--- a/gen/source/unit_threaded/runtime/runtime.d
+++ b/gen/source/unit_threaded/runtime/runtime.d
@@ -173,8 +173,8 @@ string[] dubFilesToAbsPaths(in string fileName, in string[] files) {
     // dub has done it already
     return files
         .filter!(a => a != fileName)
-        .map!(a => removePackage(a))
         .map!(a => buildNormalizedPath(a))
+        .map!(a => removePackage(a))
         .array;
 }
 
@@ -222,7 +222,7 @@ string writeUtMainFile(Options options) {
     return writeUtMainFile(options, findModuleNames(options));
 }
 
-private string defaultFileName(in string tempDirectory, in string workingDirectory) {
+string defaultUtMainPath(in string tempDirectory, in string workingDirectory) {
     import std.path: buildPath, isDirSeparator, rootName;
 
     size_t start = rootName(workingDirectory).length;
@@ -241,7 +241,7 @@ private string writeUtMainFile(Options options, in string[] modules) {
     import std.format : format;
 
     if (!options.fileName) {
-        options.fileName = defaultFileName(tempDir, getcwd);
+        options.fileName = defaultUtMainPath(tempDir, getcwd);
     }
 
     if(!haveToUpdate(options, modules)) {

--- a/gen/source/unit_threaded/runtime/runtime.d
+++ b/gen/source/unit_threaded/runtime/runtime.d
@@ -222,6 +222,16 @@ string writeUtMainFile(Options options) {
     return writeUtMainFile(options, findModuleNames(options));
 }
 
+private string defaultFileName(in string tempDirectory, in string workingDirectory) {
+    import std.path: buildPath, isDirSeparator, rootName;
+
+    size_t start = rootName(workingDirectory).length;
+    while(start < workingDirectory.length && isDirSeparator(workingDirectory[start]))
+        ++start;
+
+    return buildPath(tempDirectory, workingDirectory[start..$], "ut.d");
+}
+
 private string writeUtMainFile(Options options, in string[] modules) {
     import std.path: buildPath, dName = dirName;
     import std.stdio: writeln, File;
@@ -231,7 +241,7 @@ private string writeUtMainFile(Options options, in string[] modules) {
     import std.format : format;
 
     if (!options.fileName) {
-        options.fileName = buildPath(tempDir, getcwd[1..$], "ut.d");
+        options.fileName = defaultFileName(tempDir, getcwd);
     }
 
     if(!haveToUpdate(options, modules)) {

--- a/gen/source/unit_threaded/runtime/runtime.d
+++ b/gen/source/unit_threaded/runtime/runtime.d
@@ -170,10 +170,13 @@ string[] dubFilesToAbsPaths(in string fileName, in string[] files) {
     import std.path: buildNormalizedPath;
 
     // dub list of files, don't bother reading the filesystem since
-    // dub has done it already
+    // dub has done it already.
+    // Normalize fileName so the filter is separator-agnostic: dub describe
+    // emits native-separator paths but the -f CLI arg may use forward slashes.
+    const normalizedFileName = buildNormalizedPath(fileName);
     return files
-        .filter!(a => a != fileName)
         .map!(a => buildNormalizedPath(a))
+        .filter!(a => a != normalizedFileName)
         .map!(a => removePackage(a))
         .array;
 }

--- a/tests/unit_threaded/ut/runtime.d
+++ b/tests/unit_threaded/ut/runtime.d
@@ -19,3 +19,23 @@ unittest {
     dubFilesToAbsPaths("", [buildPath("foo", "bar", "package.d")]).shouldEqual(
         [buildPath("foo", "bar")]);
 }
+
+@("defaultUtMainPath")
+unittest {
+    import unit_threaded.should;
+    import std.path: buildPath;
+
+    version(Windows) {
+        defaultUtMainPath(`C:\Temp`, `D:\projects\unit-threaded`).shouldEqual(buildPath(
+            `C:\Temp`,
+            "projects",
+            "unit-threaded",
+            "ut.d",
+        ));
+        defaultUtMainPath(`C:\Temp`, `\\server\share\unit-threaded`).shouldEqual(
+            buildPath(`C:\Temp`, "unit-threaded", "ut.d"));
+    } else {
+        defaultUtMainPath("/tmp", "/projects/unit-threaded").shouldEqual(
+            buildPath("/tmp", "projects", "unit-threaded", "ut.d"));
+    }
+}

--- a/tests/unit_threaded/ut/runtime.d
+++ b/tests/unit_threaded/ut/runtime.d
@@ -39,3 +39,19 @@ unittest {
             buildPath("/tmp", "projects", "unit-threaded", "ut.d"));
     }
 }
+
+@("dubFilesToAbsPaths")
+unittest {
+    import unit_threaded.should;
+    import std.path: buildPath;
+
+    version(Windows) {
+        // dub describe emits native backslash paths, but the -f CLI arg
+        // from dub.json preBuildCommands may use forward slashes.
+        dubFilesToAbsPaths("bin/ut.d", [`bin\ut.d`, `source\intuit\foo.d`]).shouldEqual(
+            [buildPath("source", "intuit", "foo.d")]);
+    } else {
+        dubFilesToAbsPaths("bin/ut.d", ["bin/ut.d", "source/intuit/foo.d"]).shouldEqual(
+            [buildPath("source", "intuit", "foo.d")]);
+    }
+}

--- a/tests/unit_threaded/ut/runtime.d
+++ b/tests/unit_threaded/ut/runtime.d
@@ -9,3 +9,13 @@ unittest {
     dubFilesToAbsPaths("", ["foo/bar/package.d"]).shouldEqual(
         [buildPath("foo", "bar")]);
 }
+
+@("removePackage")
+unittest {
+    import unit_threaded.should;
+    import std.path;
+    removePackage(buildPath("foo", "bar", "package.d")).shouldEqual(
+        buildPath("foo", "bar"));
+    dubFilesToAbsPaths("", [buildPath("foo", "bar", "package.d")]).shouldEqual(
+        [buildPath("foo", "bar")]);
+}


### PR DESCRIPTION
Encountered some issues on Windows:

1. `removePackage` looks for the Linux file name "/package.d" for sanitization.
2. `writeUtMainFile` assumes a leading / (POSIX). On Windows this slices into the middle of drive/UNC roots.
3. `dubFilesToAbsPaths` runs `removePackage` before `buildNormalizedPath`, so the package-suffix check uses an unnormalized path.

I fixed these 3 and added tests for `removePackage` and `defaultUtMainPath` (the latter with Windows-specific cases for drive/UNC roots).